### PR TITLE
Add GNSS rotation heading bootstrap

### DIFF
--- a/fusioncore_core/include/fusioncore/fusioncore.hpp
+++ b/fusioncore_core/include/fusioncore/fusioncore.hpp
@@ -1,26 +1,29 @@
 #pragma once
-#include "fusioncore/ukf.hpp"
-#include "fusioncore/state.hpp"
 #include "fusioncore/motion_model.hpp"
-#include "fusioncore/sensors/imu.hpp"
 #include "fusioncore/sensors/encoder.hpp"
 #include "fusioncore/sensors/gnss.hpp"
+#include "fusioncore/sensors/imu.hpp"
 #include "fusioncore/sensors/vslam.hpp"
+#include "fusioncore/state.hpp"
+#include "fusioncore/ukf.hpp"
+
+#include <array>
 #include <chrono>
-#include <optional>
-#include <string>
 #include <deque>
 #include <functional>
-#include <array>
+#include <optional>
+#include <string>
 
-namespace fusioncore {
+namespace fusioncore
+{
 
-struct FusionCoreConfig {
-  UKFParams              ukf;
-  sensors::ImuParams     imu;
+struct FusionCoreConfig
+{
+  UKFParams ukf;
+  sensors::ImuParams imu;
   sensors::EncoderParams encoder;
-  sensors::GnssParams    gnss;
-  sensors::VslamParams   vslam;
+  sensors::GnssParams gnss;
+  sensors::VslamParams vslam;
   double min_dt = 1e-6;
   double max_dt = 1.0;
 
@@ -35,7 +38,8 @@ struct FusionCoreConfig {
   // pseudo-measurement whenever the robot has moved at least min_dist meters
   // since the last heading fusion. This is the same mechanism navsat_transform
   // uses internally and directly corrects heading from GPS geometry without
-  // relying on gyro bias estimation.
+  // relying on gyro bias estimation. Only fuses while motion is close to straight
+  // forward travel; on curves the GPS displacement bearing is not robot heading.
   // max_sigma: skip fusion if position_noise / displacement > this (rad).
   // 0.4 rad (23 deg) is a reasonable ceiling; tighter GPS gives automatic improvement.
   bool   gps_track_heading_enabled  = true;
@@ -57,7 +61,7 @@ struct FusionCoreConfig {
   // base_link, an in-place rotation makes the antenna trace a small arc. The
   // observed GNSS displacement, relative yaw from odometry/gyro, and known
   // lever arm make absolute yaw observable without a magnetometer.
-  bool   gps_rotation_heading_enabled = true;
+  bool gps_rotation_heading_enabled = true;
   double gps_rotation_heading_min_yaw_delta = 1.0;          // radians
   double gps_rotation_heading_min_arc_baseline = 0.25;      // meters
   double gps_rotation_heading_max_base_translation = 0.20;  // meters
@@ -80,18 +84,18 @@ struct FusionCoreConfig {
   // Rejects measurements that are statistically implausible.
   // Threshold is chi-squared percentile for the measurement dimension.
   // 99.9th percentile recommended: rejects GPS jumps, encoder spikes.
-  bool   outlier_rejection       = true;
-  double outlier_threshold_gnss  = 16.27;  // chi2(3, 0.999): 3D position
-  double outlier_threshold_imu   = 15.09;  // chi2(6, 0.999): 6D IMU
-  double outlier_threshold_enc   = 11.34;  // chi2(3, 0.999): 3D encoder
-  double outlier_threshold_hdg   = 10.83;  // chi2(1, 0.999): 1D heading
+  bool outlier_rejection = true;
+  double outlier_threshold_gnss = 16.27;   // chi2(3, 0.999): 3D position
+  double outlier_threshold_imu = 15.09;    // chi2(6, 0.999): 6D IMU
+  double outlier_threshold_enc = 11.34;    // chi2(3, 0.999): 3D encoder
+  double outlier_threshold_hdg = 10.83;    // chi2(1, 0.999): 1D heading
   double outlier_threshold_vslam = 22.46;  // chi2(6, 0.999): 6D pose
 
   // Adaptive noise covariance
   // Whether to enable adaptive R estimation for each sensor
-  bool adaptive_imu     = true;
+  bool adaptive_imu = true;
   bool adaptive_encoder = true;
-  bool adaptive_gnss    = true;
+  bool adaptive_gnss = true;
 
   // Whether to enable adaptive R for ground constraint pseudo-measurements (VZ=0, AZ=0).
   // When true, VZ and AZ noise automatically inflates on rough terrain as innovations grow,
@@ -121,7 +125,7 @@ struct FusionCoreConfig {
   // Zero-velocity update (ZUPT) parameters
   // Velocity threshold below which the robot is considered stationary (m/s and rad/s)
   double zupt_velocity_threshold = 0.05;
-  double zupt_angular_threshold  = 0.05;
+  double zupt_angular_threshold = 0.05;
   // Noise sigma applied during ZUPT (m/s). Tight = filter strongly believes zero velocity.
   double zupt_noise_sigma = 0.01;
 
@@ -167,7 +171,7 @@ struct FusionCoreConfig {
   // This prevents cascade failure when the filter drifts during a GPS gap
   // and then rejects the recovery fixes as apparent outliers.
   // 0 = disabled; typical value: 5
-  int    gnss_coast_n        = 5;
+  int gnss_coast_n = 5;
   // Multiplier applied to q_position each predict step while in coast mode.
   // 20.0 = 4.5x position sigma growth per second at 100Hz IMU.
   double gnss_coast_q_factor = 20.0;
@@ -210,7 +214,7 @@ struct FusionCoreConfig {
   // filter has drifted far enough that all incoming fixes fail chi2.
   // Fires exactly once per cascade (when counter first reaches this value).
   // Must be > gnss_coast_n. 0 = disabled; typical value: 15.
-  int    gnss_recovery_rejection_n = 0;
+  int gnss_recovery_rejection_n = 0;
   // XY sigma for P inflation (meters). 50m covers any realistic drift from
   // a chi2 cascade, allowing GPS to pull the filter back from up to ~100m off.
   double gnss_p_inflate_sigma = 50.0;
@@ -218,11 +222,11 @@ struct FusionCoreConfig {
 
 // How heading was validated: tracked per filter run
 enum class HeadingSource {
-  NONE           = 0,  // no independent heading: lever arm disabled
-  DUAL_ANTENNA   = 1,  // dual GNSS antenna heading received
-  IMU_ORIENTATION = 2, // AHRS/IMU published full orientation
-  GPS_TRACK      = 3,  // robot moved enough for heading to be geometric
-  GPS_ROTATION   = 4,  // GNSS antenna lever-arm arc during rotation
+  NONE = 0,             // no independent heading: lever arm disabled
+  DUAL_ANTENNA = 1,     // dual GNSS antenna heading received
+  IMU_ORIENTATION = 2,  // AHRS/IMU published full orientation
+  GPS_TRACK = 3,        // robot moved enough for heading to be geometric
+  GPS_ROTATION = 4,     // GNSS antenna lever-arm arc during rotation
 };
 
 // Why a GNSS fix was rejected (or ACCEPTED if it passed)
@@ -263,13 +267,14 @@ enum class SensorHealth {
   NOT_INIT
 };
 
-struct FusionCoreStatus {
-  bool         initialized          = false;
-  SensorHealth imu_health           = SensorHealth::NOT_INIT;
-  SensorHealth encoder_health       = SensorHealth::NOT_INIT;
-  SensorHealth gnss_health          = SensorHealth::NOT_INIT;
-  double       position_uncertainty = 0.0;
-  int          update_count         = 0;
+struct FusionCoreStatus
+{
+  bool initialized = false;
+  SensorHealth imu_health = SensorHealth::NOT_INIT;
+  SensorHealth encoder_health = SensorHealth::NOT_INIT;
+  SensorHealth gnss_health = SensorHealth::NOT_INIT;
+  double position_uncertainty = 0.0;
+  int update_count = 0;
 
   // Heading observability
   bool          heading_validated   = false;
@@ -278,10 +283,10 @@ struct FusionCoreStatus {
   double        last_heading_sigma  = 0.0;  // radians, last fused heading pseudo-measurement
 
   // Outlier rejection counters: cumulative since init()
-  int gnss_outliers  = 0;
-  int imu_outliers   = 0;
-  int enc_outliers   = 0;
-  int hdg_outliers   = 0;
+  int gnss_outliers = 0;
+  int imu_outliers = 0;
+  int enc_outliers = 0;
+  int hdg_outliers = 0;
   int vslam_outliers = 0;
 
   SensorHealth vslam_health = SensorHealth::NOT_INIT;
@@ -302,52 +307,38 @@ struct FusionCoreStatus {
   int  gnss_consecutive_rejects = 0;
 };
 
-class FusionCore {
+class FusionCore
+{
 public:
-  explicit FusionCore(const FusionCoreConfig& config = FusionCoreConfig{});
+  explicit FusionCore(const FusionCoreConfig & config = FusionCoreConfig{});
 
-  void init(const State& initial_state, double timestamp_seconds);
+  void init(const State & initial_state, double timestamp_seconds);
 
   // IMU raw update (gyro + accel)
   void update_imu(
-    double timestamp_seconds,
-    double wx, double wy, double wz,
-    double ax, double ay, double az
-  );
+    double timestamp_seconds, double wx, double wy, double wz, double ax, double ay, double az);
 
   // IMU orientation update: for IMUs that publish full orientation
   // (BNO08x, VectorNav, Xsens, etc.)
   // Calling this validates heading via HeadingSource::IMU_ORIENTATION
   void update_imu_orientation(
-    double timestamp_seconds,
-    double roll, double pitch, double yaw,
-    const double orientation_cov[9] = nullptr
-  );
+    double timestamp_seconds, double roll, double pitch, double yaw,
+    const double orientation_cov[9] = nullptr);
 
   // Encoder update
   // var_vx, var_vy, var_wz: message covariance variances (m/s)²
   // Pass -1.0 to use config params for that axis
   void update_encoder(
-    double timestamp_seconds,
-    double vx, double vy, double wz,
-    double var_vx = -1.0,
-    double var_vy = -1.0,
-    double var_wz = -1.0
-  );
+    double timestamp_seconds, double vx, double vy, double wz, double var_vx = -1.0,
+    double var_vy = -1.0, double var_wz = -1.0);
 
   // GNSS position update: ENU frame
-  bool update_gnss(
-    double timestamp_seconds,
-    const sensors::GnssFix& fix
-  );
+  bool update_gnss(double timestamp_seconds, const sensors::GnssFix & fix);
 
   // VSLAM pose update: 6-DOF position + orientation in local ENU frame.
   // Ignores the twist component of nav_msgs/Odometry entirely.
   // Returns true if accepted, false if rejected by the outlier gate.
-  bool update_pose(
-    double timestamp_seconds,
-    const sensors::VslamPose& pose
-  );
+  bool update_pose(double timestamp_seconds, const sensors::VslamPose & pose);
 
   // Non-holonomic ground constraint: fuses VZ=0 as a pseudo-measurement.
   // Call this every encoder update to prevent altitude drift in the UKF.
@@ -362,10 +353,7 @@ public:
 
   // GNSS dual antenna heading update
   // Calling this validates heading via HeadingSource::DUAL_ANTENNA
-  bool update_gnss_heading(
-    double timestamp_seconds,
-    const sensors::GnssHeading& heading
-  );
+  bool update_gnss_heading(double timestamp_seconds, const sensors::GnssHeading & heading);
 
   const State&       get_state()      const;
   FusionCoreStatus   get_status()     const;
@@ -377,15 +365,15 @@ public:
 
 private:
   FusionCoreConfig config_;
-  UKF              ukf_;
-  bool             initialized_       = false;
+  UKF ukf_;
+  bool initialized_ = false;
 
-  double last_timestamp_    = 0.0;
-  double last_imu_time_     = -1.0;
+  double last_timestamp_ = 0.0;
+  double last_imu_time_ = -1.0;
   double last_encoder_time_ = -1.0;
-  double last_gnss_time_    = -1.0;
-  double last_vslam_time_   = -1.0;
-  int    update_count_      = 0;
+  double last_gnss_time_ = -1.0;
+  double last_vslam_time_ = -1.0;
+  int update_count_ = 0;
 
   // ─── Adaptive noise covariance ───────────────────────────────────────────
   // Tracks a sliding window of innovations per sensor.
@@ -394,15 +382,16 @@ private:
 
   // Generic innovation window: stores squared innovations per dimension
   template <int z_dim>
-  struct InnovationWindow {
+  struct InnovationWindow
+  {
     using ZMatrix = Eigen::Matrix<double, z_dim, z_dim>;
     std::deque<Eigen::Matrix<double, z_dim, 1>> innovations;
     int max_size = 50;
 
-    void push(const Eigen::Matrix<double, z_dim, 1>& nu) {
+    void push(const Eigen::Matrix<double, z_dim, 1> & nu)
+    {
       innovations.push_back(nu);
-      if ((int)innovations.size() > max_size)
-        innovations.pop_front();
+      if ((int)innovations.size() > max_size) innovations.pop_front();
     }
 
     bool ready() const { return (int)innovations.size() >= max_size / 2; }
@@ -410,14 +399,14 @@ private:
     // Estimate covariance from innovation window.
     // Includes the bias term (mean^2) so systematic offsets (e.g. GPS multipath
     // pushing fixes consistently in one direction) inflate R, not just random scatter.
-    ZMatrix estimate_covariance() const {
+    ZMatrix estimate_covariance() const
+    {
       Eigen::Matrix<double, z_dim, 1> mean = Eigen::Matrix<double, z_dim, 1>::Zero();
-      for (const auto& nu : innovations)
-        mean += nu;
+      for (const auto & nu : innovations) mean += nu;
       mean /= (double)innovations.size();
 
       ZMatrix C = ZMatrix::Zero();
-      for (const auto& nu : innovations) {
+      for (const auto & nu : innovations) {
         Eigen::Matrix<double, z_dim, 1> d = nu - mean;
         C += d * d.transpose();
       }
@@ -427,43 +416,43 @@ private:
     }
   };
 
-  InnovationWindow<sensors::IMU_DIM>              imu_innovations_;
-  InnovationWindow<sensors::ENCODER_DIM>          encoder_innovations_;
-  InnovationWindow<sensors::GNSS_POS_DIM>         gnss_innovations_;
-  InnovationWindow<sensors::IMU_ORIENTATION_DIM>  imu_orient_innovations_;
-  InnovationWindow<sensors::VSLAM_POSE_DIM>       vslam_innovations_;
-  InnovationWindow<1>                             vz_innovations_;
-  InnovationWindow<1>                             az_innovations_;
+  InnovationWindow<sensors::IMU_DIM> imu_innovations_;
+  InnovationWindow<sensors::ENCODER_DIM> encoder_innovations_;
+  InnovationWindow<sensors::GNSS_POS_DIM> gnss_innovations_;
+  InnovationWindow<sensors::IMU_ORIENTATION_DIM> imu_orient_innovations_;
+  InnovationWindow<sensors::VSLAM_POSE_DIM> vslam_innovations_;
+  InnovationWindow<1> vz_innovations_;
+  InnovationWindow<1> az_innovations_;
 
   // Current adaptive R estimates: start at config values, drift toward truth
-  sensors::ImuNoiseMatrix             R_imu_;
-  sensors::EncoderNoiseMatrix         R_encoder_;
-  sensors::GnssPosNoiseMatrix         R_gnss_;
-  sensors::ImuOrientationNoiseMatrix  R_imu_orient_;
-  sensors::VslamPoseNoiseMatrix       R_vslam_;
-  Eigen::Matrix<double, 1, 1>         R_vz_;   // body-frame vertical velocity constraint
-  Eigen::Matrix<double, 1, 1>         R_az_;   // body-frame vertical accel constraint
+  sensors::ImuNoiseMatrix R_imu_;
+  sensors::EncoderNoiseMatrix R_encoder_;
+  sensors::GnssPosNoiseMatrix R_gnss_;
+  sensors::ImuOrientationNoiseMatrix R_imu_orient_;
+  sensors::VslamPoseNoiseMatrix R_vslam_;
+  Eigen::Matrix<double, 1, 1> R_vz_;  // body-frame vertical velocity constraint
+  Eigen::Matrix<double, 1, 1> R_az_;  // body-frame vertical accel constraint
 
   // Minimum R floors: adaptive R must never drop below the initially configured value.
   // A constant innovation bias (e.g. sim gravity != WGS84 gravity) has zero variance
   // after mean-subtraction and would otherwise drive R toward 1e-9, causing
   // K[position, accel] to explode and Z to drift at m/s rates.
-  sensors::ImuNoiseMatrix             R_imu_floor_;
-  sensors::EncoderNoiseMatrix         R_encoder_floor_;
-  sensors::GnssPosNoiseMatrix         R_gnss_floor_;
-  sensors::ImuOrientationNoiseMatrix  R_imu_orient_floor_;
-  sensors::VslamPoseNoiseMatrix       R_vslam_floor_;
-  Eigen::Matrix<double, 1, 1>         R_vz_floor_;
-  Eigen::Matrix<double, 1, 1>         R_az_floor_;
+  sensors::ImuNoiseMatrix R_imu_floor_;
+  sensors::EncoderNoiseMatrix R_encoder_floor_;
+  sensors::GnssPosNoiseMatrix R_gnss_floor_;
+  sensors::ImuOrientationNoiseMatrix R_imu_orient_floor_;
+  sensors::VslamPoseNoiseMatrix R_vslam_floor_;
+  Eigen::Matrix<double, 1, 1> R_vz_floor_;
+  Eigen::Matrix<double, 1, 1> R_az_floor_;
 
   bool adaptive_initialized_ = false;
 
   // Outlier rejection counters: for status reporting
-  int gnss_outliers_   = 0;
-  int imu_outliers_    = 0;
-  int enc_outliers_    = 0;
-  int hdg_outliers_    = 0;
-  int vslam_outliers_  = 0;
+  int gnss_outliers_ = 0;
+  int imu_outliers_ = 0;
+  int enc_outliers_ = 0;
+  int hdg_outliers_ = 0;
+  int vslam_outliers_ = 0;
 
   // Per-fix observability: updated on every update_gnss() call
   GnssFixDebug gnss_debug_;
@@ -474,38 +463,34 @@ private:
   double last_encoder_innovation_norm_ = 0.0;
 
   // Inertial coast mode tracking
-  int  gnss_consecutive_rejects_ = 0;
-  bool gnss_in_coast_            = false;
+  int gnss_consecutive_rejects_ = 0;
+  bool gnss_in_coast_ = false;
   // Recovery mode: after a timeout-triggered coast, accept the first returning
   // GPS fix unconditionally (bypass chi2 gate). After 7+ minutes blind, dead
   // reckoning error can be hundreds of meters, far outside the chi2 gate.
   // Without this, coast mode inflates P but can't grow sigma fast enough to
   // accept the recovery fix, causing permanent GPS rejection.
-  bool gnss_in_recovery_         = false;
+  bool gnss_in_recovery_ = false;
 
   // Mahalanobis distance test
   template <int z_dim>
   bool is_outlier(
-    const Eigen::Matrix<double, z_dim, 1>& innovation,
-    const Eigen::Matrix<double, z_dim, z_dim>& S,
-    double threshold
-  ) const;
+    const Eigen::Matrix<double, z_dim, 1> & innovation,
+    const Eigen::Matrix<double, z_dim, z_dim> & S, double threshold) const;
 
   void init_adaptive_R();
 
   template <int z_dim>
   void adapt_R(
-    Eigen::Matrix<double, z_dim, z_dim>& R,
-    const Eigen::Matrix<double, z_dim, z_dim>& R_floor,
-    InnovationWindow<z_dim>& window,
-    const Eigen::Matrix<double, z_dim, 1>& innovation,
-    bool enabled
-  );
+    Eigen::Matrix<double, z_dim, z_dim> & R, const Eigen::Matrix<double, z_dim, z_dim> & R_floor,
+    InnovationWindow<z_dim> & window, const Eigen::Matrix<double, z_dim, 1> & innovation,
+    bool enabled);
 
   // ─── State snapshot for delay compensation
-  struct StateSnapshot {
+  struct StateSnapshot
+  {
     double timestamp;
-    State  state;
+    State state;
     double last_imu_time;
     double last_encoder_time;
     double last_gnss_time;
@@ -516,7 +501,8 @@ private:
   // IMU message buffer for full replay retrodiction
   // Every raw IMU message is stored so that when a delayed GNSS arrives,
   // we replay all intermediate IMU updates instead of one big predict(dt).
-  struct ImuBufferEntry {
+  struct ImuBufferEntry
+  {
     double timestamp;
     double wx, wy, wz;
     double ax, ay, az;
@@ -525,21 +511,22 @@ private:
   std::deque<ImuBufferEntry> imu_buffer_;
 
   // Heading observability tracking
-  bool          heading_validated_ = false;
-  HeadingSource heading_source_    = HeadingSource::NONE;
+  bool heading_validated_ = false;
+  HeadingSource heading_source_ = HeadingSource::NONE;
 
   // For GPS track heading observability
-  double last_gnss_x_     = 0.0;
-  double last_gnss_y_     = 0.0;
-  bool   gnss_pos_set_    = false;
+  double last_gnss_x_ = 0.0;
+  double last_gnss_y_ = 0.0;
+  bool gnss_pos_set_ = false;
   double distance_traveled_ = 0.0;
 
   // Reference position for GPS track heading fusion.
-  // Updated only when a heading fusion fires, so displacement accumulates
-  // across multiple GPS fixes until the baseline is large enough to be reliable.
-  double last_hdg_fix_x_  = 0.0;
-  double last_hdg_fix_y_  = 0.0;
-  bool   hdg_fix_set_     = false;
+  // Updated when a valid straight segment starts or a heading fusion fires, so
+  // displacement accumulates only across nearly straight GPS fixes.
+  double last_hdg_fix_x_ = 0.0;
+  double last_hdg_fix_y_ = 0.0;
+  double last_hdg_fix_yaw_ = 0.0;
+  bool hdg_fix_set_ = false;
 
   // True after the first GPS track heading fusion has successfully fired.
   // The chi2 gate for subsequent fusions is only applied once this is true.
@@ -547,7 +534,7 @@ private:
   // at 5m (before the 7.5m baseline needed for a reliable bearing), causing
   // the chi2 gate to reject the very first heading fusion when the initial
   // heading error exceeds ~75 degrees.
-  bool   gps_track_hdg_fused_ = false;
+  bool gps_track_hdg_fused_ = false;
 
   // Returns heading 1-sigma in radians computed from P via quaternion-to-yaw Jacobian.
   double compute_heading_sigma_rad() const;
@@ -563,28 +550,23 @@ private:
   };
 
   GpsRotationHeadingWindow gps_rotation_hdg_window_;
-  bool   gps_rotation_hdg_fused_ = false;
-  double encoder_distance_       = 0.0;
-  double last_heading_sigma_     = 0.0;
+  bool gps_rotation_hdg_fused_ = false;
+  double encoder_distance_ = 0.0;
+  double last_heading_sigma_ = 0.0;
 
   void predict_to(double timestamp_seconds);
-  bool apply_gnss_update(double timestamp_seconds, const sensors::GnssFix& fix);
+  bool apply_gnss_update(double timestamp_seconds, const sensors::GnssFix & fix);
   void save_snapshot();
   bool apply_delayed_measurement(
-    double measurement_timestamp,
-    const std::function<void()>& apply_fn
-  );
+    double measurement_timestamp, const std::function<void()> & apply_fn);
   void update_distance_traveled(double x, double y, double pre_update_speed = -1.0);
+  void reset_gps_track_heading_reference(const sensors::GnssFix & fix);
   bool try_fuse_gps_rotation_heading(
-    double timestamp_seconds,
-    const sensors::GnssFix& fix,
-    const sensors::GnssPosNoiseMatrix& R_meas
-  );
+    double timestamp_seconds, const sensors::GnssFix & fix,
+    const sensors::GnssPosNoiseMatrix & R_meas);
   void reset_gps_rotation_heading_window(
-    double timestamp_seconds,
-    const sensors::GnssFix& fix,
-    const sensors::GnssPosNoiseMatrix& R_meas
-  );
+    double timestamp_seconds, const sensors::GnssFix & fix,
+    const sensors::GnssPosNoiseMatrix & R_meas);
 };
 
-} // namespace fusioncore
+}  // namespace fusioncore

--- a/fusioncore_core/include/fusioncore/fusioncore.hpp
+++ b/fusioncore_core/include/fusioncore/fusioncore.hpp
@@ -51,6 +51,20 @@ struct FusionCoreConfig {
   // is being incorrectly validated during tight turns (parking lot maneuvers).
   double gps_track_heading_min_speed    = 0.2;   // m/s
   double gps_track_heading_max_yaw_rate = 0.3;   // rad/s (~17 deg/s)
+  double gps_track_heading_max_yaw_delta = 0.15; // radians across the track window
+
+  // GPS rotation heading fusion: when a single GNSS antenna is offset from
+  // base_link, an in-place rotation makes the antenna trace a small arc. The
+  // observed GNSS displacement, relative yaw from odometry/gyro, and known
+  // lever arm make absolute yaw observable without a magnetometer.
+  bool   gps_rotation_heading_enabled = true;
+  double gps_rotation_heading_min_yaw_delta = 1.0;          // radians
+  double gps_rotation_heading_min_arc_baseline = 0.25;      // meters
+  double gps_rotation_heading_max_base_translation = 0.20;  // meters
+  double gps_rotation_heading_max_sigma = 0.4;              // radians
+  double gps_rotation_heading_sigma_floor = 0.05;           // radians
+  double gps_rotation_heading_delta_yaw_sigma = 0.03;       // radians
+  double gps_rotation_heading_max_window_s = 10.0;          // seconds
 
   // Lever arm correction is only applied when heading uncertainty is below this threshold.
   // When heading_sigma exceeds this value (e.g. during prolonged turns with no GPS track
@@ -208,6 +222,7 @@ enum class HeadingSource {
   DUAL_ANTENNA   = 1,  // dual GNSS antenna heading received
   IMU_ORIENTATION = 2, // AHRS/IMU published full orientation
   GPS_TRACK      = 3,  // robot moved enough for heading to be geometric
+  GPS_ROTATION   = 4,  // GNSS antenna lever-arm arc during rotation
 };
 
 // Why a GNSS fix was rejected (or ACCEPTED if it passed)
@@ -259,7 +274,8 @@ struct FusionCoreStatus {
   // Heading observability
   bool          heading_validated   = false;
   HeadingSource heading_source      = HeadingSource::NONE;
-  double        distance_traveled   = 0.0;
+  double        distance_traveled   = 0.0;  // meters since init
+  double        last_heading_sigma  = 0.0;  // radians, last fused heading pseudo-measurement
 
   // Outlier rejection counters: cumulative since init()
   int gnss_outliers  = 0;
@@ -536,6 +552,21 @@ private:
   // Returns heading 1-sigma in radians computed from P via quaternion-to-yaw Jacobian.
   double compute_heading_sigma_rad() const;
 
+  struct GpsRotationHeadingWindow {
+    bool set = false;
+    double timestamp = 0.0;
+    double fix_x = 0.0;
+    double fix_y = 0.0;
+    Eigen::Matrix2d fix_cov = Eigen::Matrix2d::Identity();
+    double yaw = 0.0;
+    double encoder_distance = 0.0;
+  };
+
+  GpsRotationHeadingWindow gps_rotation_hdg_window_;
+  bool   gps_rotation_hdg_fused_ = false;
+  double encoder_distance_       = 0.0;
+  double last_heading_sigma_     = 0.0;
+
   void predict_to(double timestamp_seconds);
   bool apply_gnss_update(double timestamp_seconds, const sensors::GnssFix& fix);
   void save_snapshot();
@@ -544,6 +575,16 @@ private:
     const std::function<void()>& apply_fn
   );
   void update_distance_traveled(double x, double y, double pre_update_speed = -1.0);
+  bool try_fuse_gps_rotation_heading(
+    double timestamp_seconds,
+    const sensors::GnssFix& fix,
+    const sensors::GnssPosNoiseMatrix& R_meas
+  );
+  void reset_gps_rotation_heading_window(
+    double timestamp_seconds,
+    const sensors::GnssFix& fix,
+    const sensors::GnssPosNoiseMatrix& R_meas
+  );
 };
 
 } // namespace fusioncore

--- a/fusioncore_core/include/fusioncore/ukf.hpp
+++ b/fusioncore_core/include/fusioncore/ukf.hpp
@@ -3,6 +3,7 @@
 #include "fusioncore/state.hpp"
 #include "fusioncore/motion_model.hpp"
 #include <Eigen/Dense>
+#include <array>
 #include <functional>
 #include <memory>
 
@@ -51,6 +52,17 @@ public:
     const Eigen::Matrix<double, z_dim, 1>& z,
     const std::function<Eigen::Matrix<double, z_dim, 1>(const StateVector&)>& h,
     const Eigen::Matrix<double, z_dim, z_dim>& R,
+    unsigned int angle_dims = 0
+  );
+
+  // Update step with selected state rows blocked from the Kalman correction.
+  // Mask value true = state element may be corrected; false = leave it unchanged.
+  template <int z_dim>
+  Eigen::Matrix<double, z_dim, 1> update_masked(
+    const Eigen::Matrix<double, z_dim, 1>& z,
+    const std::function<Eigen::Matrix<double, z_dim, 1>(const StateVector&)>& h,
+    const Eigen::Matrix<double, z_dim, z_dim>& R,
+    const std::array<bool, STATE_DIM>& state_update_mask,
     unsigned int angle_dims = 0
   );
 

--- a/fusioncore_core/src/fusioncore.cpp
+++ b/fusioncore_core/src/fusioncore.cpp
@@ -1042,8 +1042,7 @@ bool FusionCore::apply_gnss_update(double timestamp_seconds, const sensors::Gnss
   // so the baseline is large enough and the bearing represents robot heading.
   if (
     config_.gps_track_heading_enabled &&
-    (!heading_validated_ || heading_source_ == HeadingSource::GPS_TRACK ||
-     heading_source_ == HeadingSource::GPS_ROTATION)) {
+    (!heading_validated_ || heading_source_ == HeadingSource::GPS_TRACK)) {
     if (!hdg_fix_set_) {
       // Initialize reference on first accepted fix; no heading yet.
       reset_gps_track_heading_reference(fix);

--- a/fusioncore_core/src/fusioncore.cpp
+++ b/fusioncore_core/src/fusioncore.cpp
@@ -5,6 +5,17 @@
 
 namespace fusioncore {
 
+namespace {
+
+double normalize_angle(double angle)
+{
+  angle = std::fmod(angle + M_PI, 2.0 * M_PI);
+  if (angle < 0.0) angle += 2.0 * M_PI;
+  return angle - M_PI;
+}
+
+}  // namespace
+
 // ─── Adaptive noise covariance implementation ─────────────────────────────
 
 // ─── Mahalanobis outlier rejection ────────────────────────────────────────
@@ -128,6 +139,10 @@ void FusionCore::init(const State& initial_state, double timestamp_seconds) {
   last_hdg_fix_x_       = 0.0;
   last_hdg_fix_y_       = 0.0;
   gps_track_hdg_fused_  = false;
+  gps_rotation_hdg_window_ = GpsRotationHeadingWindow{};
+  gps_rotation_hdg_fused_  = false;
+  encoder_distance_        = 0.0;
+  last_heading_sigma_      = 0.0;
 
   // Reset snapshot buffer
   snapshot_buffer_.clear();
@@ -166,6 +181,10 @@ void FusionCore::reset() {
   last_hdg_fix_x_       = 0.0;
   last_hdg_fix_y_       = 0.0;
   gps_track_hdg_fused_  = false;
+  gps_rotation_hdg_window_ = GpsRotationHeadingWindow{};
+  gps_rotation_hdg_fused_  = false;
+  encoder_distance_        = 0.0;
+  last_heading_sigma_      = 0.0;
   snapshot_buffer_.clear();
   imu_buffer_.clear();
   gnss_consecutive_rejects_ = 0;
@@ -382,7 +401,7 @@ void FusionCore::update_distance_traveled(double x, double y, double pre_update_
   double yaw_rate = std::abs(ukf_.state().x[WZ]);
 
   bool motion_is_valid = (state_speed >= config_.gps_track_heading_min_speed) &&
-                         (yaw_rate    <= config_.gps_track_heading_max_yaw_rate);
+                          (yaw_rate    <= config_.gps_track_heading_max_yaw_rate);
 
   if (motion_is_valid) {
     distance_traveled_ += dist;
@@ -598,6 +617,13 @@ void FusionCore::update_encoder(
     adapt_R<sensors::ENCODER_DIM>(R_encoder_, R_encoder_floor_, encoder_innovations_, innovation, config_.adaptive_encoder);
   }
 
+  if (last_encoder_time_ >= 0.0) {
+    const double dt = timestamp_seconds - last_encoder_time_;
+    if (dt > config_.min_dt && dt < config_.max_dt) {
+      encoder_distance_ += std::sqrt(vx * vx + vy * vy) * dt;
+    }
+  }
+
   last_encoder_time_ = timestamp_seconds;
   ++update_count_;
 }
@@ -764,6 +790,131 @@ bool FusionCore::update_gnss(
   return true;
 }
 
+void FusionCore::reset_gps_rotation_heading_window(
+  double timestamp_seconds,
+  const sensors::GnssFix& fix,
+  const sensors::GnssPosNoiseMatrix& R_meas)
+{
+  gps_rotation_hdg_window_.set = true;
+  gps_rotation_hdg_window_.timestamp = timestamp_seconds;
+  gps_rotation_hdg_window_.fix_x = fix.x;
+  gps_rotation_hdg_window_.fix_y = fix.y;
+  gps_rotation_hdg_window_.fix_cov = R_meas.topLeftCorner<2, 2>();
+  gps_rotation_hdg_window_.yaw = ukf_.state().yaw();
+  gps_rotation_hdg_window_.encoder_distance = encoder_distance_;
+}
+
+bool FusionCore::try_fuse_gps_rotation_heading(
+  double timestamp_seconds,
+  const sensors::GnssFix& fix,
+  const sensors::GnssPosNoiseMatrix& R_meas)
+{
+  if (!config_.gps_rotation_heading_enabled || fix.lever_arm.is_zero()) return false;
+
+  if (heading_validated_ &&
+      heading_source_ != HeadingSource::GPS_TRACK &&
+      heading_source_ != HeadingSource::GPS_ROTATION) {
+    return false;
+  }
+
+  const Eigen::Vector2d lever(fix.lever_arm.x, fix.lever_arm.y);
+  if (lever.norm() < 1e-6) return false;
+
+  if (!gps_rotation_hdg_window_.set) {
+    reset_gps_rotation_heading_window(timestamp_seconds, fix, R_meas);
+    return false;
+  }
+
+  if (config_.gps_rotation_heading_max_window_s > 0.0 &&
+      timestamp_seconds - gps_rotation_hdg_window_.timestamp >
+        config_.gps_rotation_heading_max_window_s) {
+    reset_gps_rotation_heading_window(timestamp_seconds, fix, R_meas);
+    return false;
+  }
+
+  const double base_translation = encoder_distance_ - gps_rotation_hdg_window_.encoder_distance;
+  if (base_translation > config_.gps_rotation_heading_max_base_translation) {
+    reset_gps_rotation_heading_window(timestamp_seconds, fix, R_meas);
+    return false;
+  }
+
+  const double current_yaw = ukf_.state().yaw();
+  const double delta_yaw = normalize_angle(current_yaw - gps_rotation_hdg_window_.yaw);
+  if (std::abs(delta_yaw) < config_.gps_rotation_heading_min_yaw_delta) return false;
+
+  const double c = std::cos(delta_yaw);
+  const double s = std::sin(delta_yaw);
+  const Eigen::Vector2d arc_body(
+    (c - 1.0) * lever.x() - s * lever.y(),
+    s * lever.x() + (c - 1.0) * lever.y());
+  const double arc_len = arc_body.norm();
+  if (arc_len < config_.gps_rotation_heading_min_arc_baseline) return false;
+
+  const Eigen::Vector2d observed(
+    fix.x - gps_rotation_hdg_window_.fix_x,
+    fix.y - gps_rotation_hdg_window_.fix_y);
+  const double observed_len = observed.norm();
+  if (observed_len < 1e-6) return false;
+
+  const Eigen::Matrix2d C_delta = gps_rotation_hdg_window_.fix_cov + R_meas.topLeftCorner<2, 2>();
+  const Eigen::Vector2d u_perp(-observed.y() / observed_len, observed.x() / observed_len);
+  const double lateral_var = std::max(0.0, (u_perp.transpose() * C_delta * u_perp)(0, 0));
+  const double sigma_floor = config_.gps_rotation_heading_sigma_floor;
+  const double delta_yaw_sigma = config_.gps_rotation_heading_delta_yaw_sigma;
+  const double sigma_hdg = std::sqrt(
+    lateral_var / (arc_len * arc_len) +
+    delta_yaw_sigma * delta_yaw_sigma +
+    sigma_floor * sigma_floor);
+
+  if (!std::isfinite(sigma_hdg) || sigma_hdg > config_.gps_rotation_heading_max_sigma) {
+    return false;
+  }
+
+  const double yaw_start_est =
+    std::atan2(observed.y(), observed.x()) - std::atan2(arc_body.y(), arc_body.x());
+  const double yaw_current_est = normalize_angle(yaw_start_est + delta_yaw);
+
+  sensors::GnssHdgMeasurement z_hdg;
+  z_hdg[0] = yaw_current_est;
+
+  sensors::GnssHdgNoiseMatrix R_hdg;
+  R_hdg(0,0) = sigma_hdg * sigma_hdg;
+
+  constexpr unsigned int HDG_ANGLE_DIMS = 0b1;
+
+  bool fuse = true;
+  if (config_.outlier_rejection && gps_rotation_hdg_fused_) {
+    sensors::GnssHdgMeasurement innov_pre;
+    sensors::GnssHdgNoiseMatrix S_pre;
+    ukf_.predict_measurement<sensors::GNSS_HDG_DIM>(
+      z_hdg, sensors::gnss_hdg_measurement_function, R_hdg,
+      innov_pre, S_pre, HDG_ANGLE_DIMS);
+    fuse = !is_outlier<sensors::GNSS_HDG_DIM>(innov_pre, S_pre, config_.outlier_threshold_hdg);
+  }
+
+  if (!fuse) {
+    ++hdg_outliers_;
+    reset_gps_rotation_heading_window(timestamp_seconds, fix, R_meas);
+    return false;
+  }
+
+  ukf_.update<sensors::GNSS_HDG_DIM>(
+    z_hdg, sensors::gnss_hdg_measurement_function, R_hdg, HDG_ANGLE_DIMS);
+
+  gps_rotation_hdg_fused_ = true;
+  last_heading_sigma_ = sigma_hdg;
+
+  if (!heading_validated_ ||
+      heading_source_ == HeadingSource::GPS_TRACK ||
+      heading_source_ == HeadingSource::GPS_ROTATION) {
+    heading_validated_ = true;
+    heading_source_ = HeadingSource::GPS_ROTATION;
+  }
+
+  reset_gps_rotation_heading_window(timestamp_seconds, fix, R_meas);
+  return true;
+}
+
 bool FusionCore::apply_gnss_update(
   double timestamp_seconds,
   const sensors::GnssFix& fix)
@@ -867,6 +1018,8 @@ bool FusionCore::apply_gnss_update(
   // Track innovation for adaptive GNSS noise estimation
   adapt_R<sensors::GNSS_POS_DIM>(R_gnss_, R_gnss_floor_, gnss_innovations_, innovation, config_.adaptive_gnss);
 
+  try_fuse_gps_rotation_heading(timestamp_seconds, fix, R_meas);
+
   // GPS track heading fusion: fuse the displacement bearing as a yaw update.
   // This is the same mechanism navsat_transform uses for RL-EKF and directly
   // corrects heading from GPS geometry rather than relying on gyro bias estimation.
@@ -916,6 +1069,7 @@ bool FusionCore::apply_gnss_update(
             ukf_.update<sensors::GNSS_HDG_DIM>(
               z_hdg, sensors::gnss_hdg_measurement_function, R_hdg, HDG_ANGLE_DIMS);
             gps_track_hdg_fused_ = true;
+            last_heading_sigma_ = sigma_hdg;
 
             if (!heading_validated_) {
               heading_validated_ = true;
@@ -973,6 +1127,7 @@ bool FusionCore::update_gnss_heading(
 
   ukf_.update<sensors::GNSS_HDG_DIM>(
     z, sensors::gnss_hdg_measurement_function, R, HDG_ANGLE_DIMS);
+  last_heading_sigma_ = std::sqrt(R(0,0));
 
   // Dual antenna heading is the strongest possible heading validation
   // Override any weaker source
@@ -1019,6 +1174,7 @@ FusionCoreStatus FusionCore::get_status() const {
   status.heading_validated = heading_validated_;
   status.heading_source    = heading_source_;
   status.distance_traveled = distance_traveled_;
+  status.last_heading_sigma = last_heading_sigma_;
 
   status.vslam_health =
     last_vslam_time_ < 0.0 ? SensorHealth::NOT_INIT :

--- a/fusioncore_core/src/fusioncore.cpp
+++ b/fusioncore_core/src/fusioncore.cpp
@@ -830,6 +830,11 @@ bool FusionCore::try_fuse_gps_rotation_heading(
     heading_source_ != HeadingSource::GPS_ROTATION) {
     return false;
   }
+  if (
+    heading_validated_ && heading_source_ == HeadingSource::GPS_ROTATION &&
+    gps_rotation_hdg_fused_) {
+    return false;
+  }
 
   const Eigen::Vector2d lever(fix.lever_arm.x, fix.lever_arm.y);
   if (lever.norm() < 1e-6) return false;
@@ -933,6 +938,33 @@ bool FusionCore::apply_gnss_update(double timestamp_seconds, const sensors::Gnss
   z[1] = fix.y;
   z[2] = fix.z;
 
+  double heading_sigma_rad = compute_heading_sigma_rad();
+  double heading_sigma_deg = heading_sigma_rad * 180.0 / M_PI;
+  gnss_debug_.heading_sigma_deg = heading_sigma_deg;
+
+  bool heading_reliable = heading_validated_ &&
+    (heading_sigma_deg <= config_.gnss_lever_arm_max_heading_sigma_deg);
+  bool use_lever_arm = !fix.lever_arm.is_zero() && heading_reliable;
+  gnss_debug_.lever_arm_used = use_lever_arm;
+
+  // Convert antenna position to base_link position without letting a plain
+  // GNSS position update act as another yaw measurement through the lever arm.
+  if (use_lever_arm) {
+    const auto & state = ukf_.state().x;
+    double R_body_to_world[3][3];
+    quat_to_rotation_matrix(
+      state[QW], state[QX], state[QY], state[QZ], R_body_to_world);
+    z[0] -= R_body_to_world[0][0] * fix.lever_arm.x +
+            R_body_to_world[0][1] * fix.lever_arm.y +
+            R_body_to_world[0][2] * fix.lever_arm.z;
+    z[1] -= R_body_to_world[1][0] * fix.lever_arm.x +
+            R_body_to_world[1][1] * fix.lever_arm.y +
+            R_body_to_world[1][2] * fix.lever_arm.z;
+    z[2] -= R_body_to_world[2][0] * fix.lever_arm.x +
+            R_body_to_world[2][1] * fix.lever_arm.y +
+            R_body_to_world[2][2] * fix.lever_arm.z;
+  }
+
   // Start with message covariance or HDOP-based estimate
   sensors::GnssPosNoiseMatrix R = sensors::gnss_pos_noise_matrix(config_.gnss, fix);
 
@@ -957,18 +989,8 @@ bool FusionCore::apply_gnss_update(double timestamp_seconds, const sensors::Gnss
     for (int i = 0; i < 3; ++i) R(i, i) = std::max(R(i, i), R_gnss_(i, i));
   }
 
-  double heading_sigma_rad = compute_heading_sigma_rad();
-  double heading_sigma_deg = heading_sigma_rad * 180.0 / M_PI;
-  gnss_debug_.heading_sigma_deg = heading_sigma_deg;
-
-  bool heading_reliable = heading_validated_ &&
-    (heading_sigma_deg <= config_.gnss_lever_arm_max_heading_sigma_deg);
-  bool use_lever_arm = !fix.lever_arm.is_zero() && heading_reliable;
-  gnss_debug_.lever_arm_used = use_lever_arm;
-
-  auto h_gnss = use_lever_arm ? sensors::gnss_pos_measurement_function_with_lever_arm(fix.lever_arm)
-                              : std::function<sensors::GnssPosMeasurement(const StateVector &)>(
-                                  sensors::gnss_pos_measurement_function);
+  std::function<sensors::GnssPosMeasurement(const StateVector &)> h_gnss =
+    sensors::gnss_pos_measurement_function;
 
   if (config_.outlier_rejection) {
     sensors::GnssPosMeasurement innovation_pre;
@@ -1019,8 +1041,25 @@ bool FusionCore::apply_gnss_update(double timestamp_seconds, const sensors::Gnss
   }
   gnss_consecutive_rejects_ = 0;
 
-  Eigen::Matrix<double, sensors::GNSS_POS_DIM, 1> innovation =
-    ukf_.update<sensors::GNSS_POS_DIM>(z, h_gnss, R);
+  Eigen::Matrix<double, sensors::GNSS_POS_DIM, 1> innovation;
+  if (heading_validated_) {
+    std::array<bool, STATE_DIM> state_update_mask;
+    state_update_mask.fill(true);
+    state_update_mask[QW] = false;
+    state_update_mask[QX] = false;
+    state_update_mask[QY] = false;
+    state_update_mask[QZ] = false;
+    state_update_mask[WX] = false;
+    state_update_mask[WY] = false;
+    state_update_mask[WZ] = false;
+    state_update_mask[B_GX] = false;
+    state_update_mask[B_GY] = false;
+    state_update_mask[B_GZ] = false;
+    state_update_mask[B_EWZ] = false;
+    innovation = ukf_.update_masked<sensors::GNSS_POS_DIM>(z, h_gnss, R, state_update_mask);
+  } else {
+    innovation = ukf_.update<sensors::GNSS_POS_DIM>(z, h_gnss, R);
+  }
 
   // Update observability state for accepted fix
   gnss_debug_.accepted           = true;

--- a/fusioncore_core/src/fusioncore.cpp
+++ b/fusioncore_core/src/fusioncore.cpp
@@ -1,11 +1,15 @@
 #include "fusioncore/fusioncore.hpp"
+
 #include "fusioncore/sensors/imu.hpp"
-#include <stdexcept>
+
 #include <cmath>
+#include <stdexcept>
 
-namespace fusioncore {
+namespace fusioncore
+{
 
-namespace {
+namespace
+{
 
 double normalize_angle(double angle)
 {
@@ -22,8 +26,7 @@ double normalize_angle(double angle)
 
 template <int z_dim>
 bool FusionCore::is_outlier(
-  const Eigen::Matrix<double, z_dim, 1>& innovation,
-  const Eigen::Matrix<double, z_dim, z_dim>& S,
+  const Eigen::Matrix<double, z_dim, 1> & innovation, const Eigen::Matrix<double, z_dim, z_dim> & S,
   double threshold) const
 {
   // Mahalanobis distance squared: d² = νᵀ · S⁻¹ · ν
@@ -34,61 +37,52 @@ bool FusionCore::is_outlier(
 
 // Explicit instantiations
 template bool FusionCore::is_outlier<2>(
-  const Eigen::Matrix<double, 2, 1>&,
-  const Eigen::Matrix<double, 2, 2>&,
-  double) const;
+  const Eigen::Matrix<double, 2, 1> &, const Eigen::Matrix<double, 2, 2> &, double) const;
 
 template bool FusionCore::is_outlier<1>(
-  const Eigen::Matrix<double, 1, 1>&,
-  const Eigen::Matrix<double, 1, 1>&,
-  double) const;
+  const Eigen::Matrix<double, 1, 1> &, const Eigen::Matrix<double, 1, 1> &, double) const;
 
 template bool FusionCore::is_outlier<3>(
-  const Eigen::Matrix<double, 3, 1>&,
-  const Eigen::Matrix<double, 3, 3>&,
-  double) const;
+  const Eigen::Matrix<double, 3, 1> &, const Eigen::Matrix<double, 3, 3> &, double) const;
 
 template bool FusionCore::is_outlier<6>(
-  const Eigen::Matrix<double, 6, 1>&,
-  const Eigen::Matrix<double, 6, 6>&,
-  double) const;
+  const Eigen::Matrix<double, 6, 1> &, const Eigen::Matrix<double, 6, 6> &, double) const;
 
-void FusionCore::init_adaptive_R() {
-  R_imu_         = sensors::imu_noise_matrix(config_.imu);
-  R_encoder_     = sensors::encoder_noise_matrix(config_.encoder);
-  R_gnss_        = sensors::GnssPosNoiseMatrix::Identity();  // will be set per-fix
-  R_imu_orient_  = sensors::imu_orientation_noise_matrix(sensors::ImuOrientationParams{});
-  R_vslam_       = sensors::vslam_pose_noise_matrix(config_.vslam, sensors::VslamPose{});
+void FusionCore::init_adaptive_R()
+{
+  R_imu_ = sensors::imu_noise_matrix(config_.imu);
+  R_encoder_ = sensors::encoder_noise_matrix(config_.encoder);
+  R_gnss_ = sensors::GnssPosNoiseMatrix::Identity();  // will be set per-fix
+  R_imu_orient_ = sensors::imu_orientation_noise_matrix(sensors::ImuOrientationParams{});
+  R_vslam_ = sensors::vslam_pose_noise_matrix(config_.vslam, sensors::VslamPose{});
 
-  R_vz_(0,0) = config_.ground_constraint_vz_sigma * config_.ground_constraint_vz_sigma;
-  R_az_(0,0) = config_.ground_constraint_az_sigma * config_.ground_constraint_az_sigma;
+  R_vz_(0, 0) = config_.ground_constraint_vz_sigma * config_.ground_constraint_vz_sigma;
+  R_az_(0, 0) = config_.ground_constraint_az_sigma * config_.ground_constraint_az_sigma;
 
   // Save floors: adaptive R must never drop below the initially configured sensor noise.
-  R_imu_floor_        = R_imu_;
-  R_encoder_floor_    = R_encoder_;
-  R_gnss_floor_       = R_gnss_;
+  R_imu_floor_ = R_imu_;
+  R_encoder_floor_ = R_encoder_;
+  R_gnss_floor_ = R_gnss_;
   R_imu_orient_floor_ = R_imu_orient_;
-  R_vslam_floor_      = R_vslam_;
-  R_vz_floor_         = R_vz_;
-  R_az_floor_         = R_az_;
+  R_vslam_floor_ = R_vslam_;
+  R_vz_floor_ = R_vz_;
+  R_az_floor_ = R_az_;
 
-  imu_innovations_.max_size         = config_.adaptive_window;
-  encoder_innovations_.max_size     = config_.adaptive_window;
-  gnss_innovations_.max_size        = config_.adaptive_window;
-  imu_orient_innovations_.max_size  = config_.adaptive_window;
-  vslam_innovations_.max_size       = config_.adaptive_window;
-  vz_innovations_.max_size          = config_.adaptive_window;
-  az_innovations_.max_size          = config_.adaptive_window;
+  imu_innovations_.max_size = config_.adaptive_window;
+  encoder_innovations_.max_size = config_.adaptive_window;
+  gnss_innovations_.max_size = config_.adaptive_window;
+  imu_orient_innovations_.max_size = config_.adaptive_window;
+  vslam_innovations_.max_size = config_.adaptive_window;
+  vz_innovations_.max_size = config_.adaptive_window;
+  az_innovations_.max_size = config_.adaptive_window;
 
   adaptive_initialized_ = true;
 }
 
 template <int z_dim>
 void FusionCore::adapt_R(
-  Eigen::Matrix<double, z_dim, z_dim>& R,
-  const Eigen::Matrix<double, z_dim, z_dim>& R_floor,
-  InnovationWindow<z_dim>& window,
-  const Eigen::Matrix<double, z_dim, 1>& innovation,
+  Eigen::Matrix<double, z_dim, z_dim> & R, const Eigen::Matrix<double, z_dim, z_dim> & R_floor,
+  InnovationWindow<z_dim> & window, const Eigen::Matrix<double, z_dim, 1> & innovation,
   bool enabled)
 {
   window.push(innovation);
@@ -107,42 +101,43 @@ void FusionCore::adapt_R(
   // variance after mean-subtraction and would otherwise drive R toward 1e-9,
   // causing K[position, accel] to explode and Z to drift at m/s rates.
   for (int i = 0; i < z_dim; ++i) {
-    if (R(i,i) < R_floor(i,i)) R(i,i) = R_floor(i,i);
+    if (R(i, i) < R_floor(i, i)) R(i, i) = R_floor(i, i);
   }
 }
 
-FusionCore::FusionCore(const FusionCoreConfig& config)
-  : config_(config), ukf_(config.ukf)
+FusionCore::FusionCore(const FusionCoreConfig & config) : config_(config), ukf_(config.ukf)
 {
   if (config.motion_model) {
     ukf_.set_motion_model(config.motion_model);
   }
 }
 
-void FusionCore::init(const State& initial_state, double timestamp_seconds) {
+void FusionCore::init(const State & initial_state, double timestamp_seconds)
+{
   ukf_.init(initial_state);
-  last_timestamp_    = timestamp_seconds;
-  last_imu_time_     = -1.0;
+  last_timestamp_ = timestamp_seconds;
+  last_imu_time_ = -1.0;
   last_encoder_time_ = -1.0;
-  last_gnss_time_    = -1.0;
-  update_count_      = 0;
-  initialized_       = true;
+  last_gnss_time_ = -1.0;
+  update_count_ = 0;
+  initialized_ = true;
 
   // Reset heading observability
   heading_validated_ = false;
-  heading_source_    = HeadingSource::NONE;
-  gnss_pos_set_      = false;
+  heading_source_ = HeadingSource::NONE;
+  gnss_pos_set_ = false;
   distance_traveled_ = 0.0;
-  last_gnss_x_       = 0.0;
-  last_gnss_y_       = 0.0;
-  hdg_fix_set_          = false;
-  last_hdg_fix_x_       = 0.0;
-  last_hdg_fix_y_       = 0.0;
-  gps_track_hdg_fused_  = false;
+  last_gnss_x_ = 0.0;
+  last_gnss_y_ = 0.0;
+  hdg_fix_set_ = false;
+  last_hdg_fix_x_ = 0.0;
+  last_hdg_fix_y_ = 0.0;
+  last_hdg_fix_yaw_ = 0.0;
+  gps_track_hdg_fused_ = false;
   gps_rotation_hdg_window_ = GpsRotationHeadingWindow{};
-  gps_rotation_hdg_fused_  = false;
-  encoder_distance_        = 0.0;
-  last_heading_sigma_      = 0.0;
+  gps_rotation_hdg_fused_ = false;
+  encoder_distance_ = 0.0;
+  last_heading_sigma_ = 0.0;
 
   // Reset snapshot buffer
   snapshot_buffer_.clear();
@@ -150,8 +145,8 @@ void FusionCore::init(const State& initial_state, double timestamp_seconds) {
 
   // Reset coast mode state
   gnss_consecutive_rejects_ = 0;
-  gnss_in_coast_            = false;
-  gnss_in_recovery_         = false;
+  gnss_in_coast_ = false;
+  gnss_in_recovery_ = false;
   ukf_.set_position_noise_scale(1.0);
   ukf_.set_gyro_bias_noise_scale(1.0);
 
@@ -165,31 +160,33 @@ void FusionCore::init(const State& initial_state, double timestamp_seconds) {
   init_adaptive_R();
 }
 
-void FusionCore::reset() {
-  initialized_       = false;
-  last_timestamp_    = 0.0;
-  last_imu_time_     = -1.0;
+void FusionCore::reset()
+{
+  initialized_ = false;
+  last_timestamp_ = 0.0;
+  last_imu_time_ = -1.0;
   last_encoder_time_ = -1.0;
-  last_gnss_time_    = -1.0;
-  last_vslam_time_   = -1.0;
-  update_count_      = 0;
+  last_gnss_time_ = -1.0;
+  last_vslam_time_ = -1.0;
+  update_count_ = 0;
   heading_validated_ = false;
-  heading_source_    = HeadingSource::NONE;
-  gnss_pos_set_      = false;
+  heading_source_ = HeadingSource::NONE;
+  gnss_pos_set_ = false;
   distance_traveled_ = 0.0;
-  hdg_fix_set_          = false;
-  last_hdg_fix_x_       = 0.0;
-  last_hdg_fix_y_       = 0.0;
-  gps_track_hdg_fused_  = false;
+  hdg_fix_set_ = false;
+  last_hdg_fix_x_ = 0.0;
+  last_hdg_fix_y_ = 0.0;
+  last_hdg_fix_yaw_ = 0.0;
+  gps_track_hdg_fused_ = false;
   gps_rotation_hdg_window_ = GpsRotationHeadingWindow{};
-  gps_rotation_hdg_fused_  = false;
-  encoder_distance_        = 0.0;
-  last_heading_sigma_      = 0.0;
+  gps_rotation_hdg_fused_ = false;
+  encoder_distance_ = 0.0;
+  last_heading_sigma_ = 0.0;
   snapshot_buffer_.clear();
   imu_buffer_.clear();
   gnss_consecutive_rejects_ = 0;
-  gnss_in_coast_            = false;
-  gnss_in_recovery_         = false;
+  gnss_in_coast_ = false;
+  gnss_in_recovery_ = false;
   ukf_.set_position_noise_scale(1.0);
   ukf_.set_gyro_bias_noise_scale(1.0);
 
@@ -199,13 +196,14 @@ void FusionCore::reset() {
   last_encoder_innovation_norm_ = 0.0;
 }
 
-void FusionCore::save_snapshot() {
+void FusionCore::save_snapshot()
+{
   StateSnapshot snap;
-  snap.timestamp        = last_timestamp_;
-  snap.state            = ukf_.state();
-  snap.last_imu_time    = last_imu_time_;
+  snap.timestamp = last_timestamp_;
+  snap.state = ukf_.state();
+  snap.last_imu_time = last_imu_time_;
   snap.last_encoder_time = last_encoder_time_;
-  snap.last_gnss_time   = last_gnss_time_;
+  snap.last_gnss_time = last_gnss_time_;
 
   snapshot_buffer_.push_back(snap);
 
@@ -222,9 +220,8 @@ void FusionCore::save_snapshot() {
 //
 // Returns false if the measurement is too old or no snapshots exist.
 bool FusionCore::apply_delayed_measurement(
-  double measurement_timestamp,
-  const std::function<void()>& apply_fn
-) {
+  double measurement_timestamp, const std::function<void()> & apply_fn)
+{
   if (snapshot_buffer_.empty()) return false;
 
   double delay = last_timestamp_ - measurement_timestamp;
@@ -254,17 +251,17 @@ bool FusionCore::apply_delayed_measurement(
   }
 
   // Save current state to restore after re-prediction
-  double current_time     = last_timestamp_;
-  double current_imu      = last_imu_time_;
-  double current_encoder  = last_encoder_time_;
-  double current_gnss     = last_gnss_time_;
+  double current_time = last_timestamp_;
+  double current_imu = last_imu_time_;
+  double current_encoder = last_encoder_time_;
+  double current_gnss = last_gnss_time_;
 
   // Roll back to snapshot
   ukf_.init(best_snap.state);
-  last_timestamp_     = best_snap.timestamp;
-  last_imu_time_      = best_snap.last_imu_time;
-  last_encoder_time_  = best_snap.last_encoder_time;
-  last_gnss_time_     = best_snap.last_gnss_time;
+  last_timestamp_ = best_snap.timestamp;
+  last_imu_time_ = best_snap.last_imu_time;
+  last_encoder_time_ = best_snap.last_encoder_time;
+  last_gnss_time_ = best_snap.last_gnss_time;
 
   // Apply the delayed measurement (predict_to inside apply_fn handles timing)
   apply_fn();
@@ -274,11 +271,11 @@ bool FusionCore::apply_delayed_measurement(
   // between the snapshot time and current_time in chronological order.
   // This correctly evolves the state through all intermediate dynamics.
   double replay_start = last_timestamp_;
-  bool replayed_any   = false;
+  bool replayed_any = false;
 
-  for (const auto& imu : imu_buffer_) {
+  for (const auto & imu : imu_buffer_) {
     if (imu.timestamp <= replay_start) continue;
-    if (imu.timestamp >  current_time) break;
+    if (imu.timestamp > current_time) break;
 
     double dt = imu.timestamp - last_timestamp_;
     if (dt > config_.min_dt && dt <= config_.max_dt) {
@@ -287,8 +284,12 @@ bool FusionCore::apply_delayed_measurement(
 
       // Re-apply the IMU measurement so the filter sees the real dynamics
       sensors::ImuMeasurement z;
-      z[0] = imu.wx; z[1] = imu.wy; z[2] = imu.wz;
-      z[3] = imu.ax; z[4] = imu.ay; z[5] = imu.az;
+      z[0] = imu.wx;
+      z[1] = imu.wy;
+      z[2] = imu.wz;
+      z[3] = imu.ax;
+      z[4] = imu.ay;
+      z[5] = imu.az;
       ukf_.update<sensors::IMU_DIM>(z, sensors::imu_measurement_function, imu.R);
       replayed_any = true;
     }
@@ -302,10 +303,10 @@ bool FusionCore::apply_delayed_measurement(
     }
   }
 
-  last_timestamp_    = current_time;
-  last_imu_time_     = current_imu;
+  last_timestamp_ = current_time;
+  last_imu_time_ = current_imu;
   last_encoder_time_ = current_encoder;
-  last_gnss_time_    = current_gnss;
+  last_gnss_time_ = current_gnss;
 
   return true;
 }
@@ -339,12 +340,9 @@ void FusionCore::predict_to(double timestamp_seconds) {
   // Enter coast mode on GPS timeout: receiver went silent (mode=2, tunnel,
   // power loss) rather than publishing rejectable fixes. Consecutive-reject
   // coast mode won't fire in this case because there are no fixes to reject.
-  if (config_.gnss_coast_timeout_s > 0.0 &&
-      config_.gnss_coast_n > 0 &&
-      last_gnss_time_ >= 0.0 &&
-      !gnss_in_coast_ &&
-      (timestamp_seconds - last_gnss_time_) > config_.gnss_coast_timeout_s)
-  {
+  if (
+    config_.gnss_coast_timeout_s > 0.0 && config_.gnss_coast_n > 0 && last_gnss_time_ >= 0.0 &&
+    !gnss_in_coast_ && (timestamp_seconds - last_gnss_time_) > config_.gnss_coast_timeout_s) {
     gnss_in_coast_ = true;
     ukf_.set_position_noise_scale(config_.gnss_coast_q_factor);
     ukf_.set_gyro_bias_noise_scale(config_.gnss_coast_q_bias_factor);
@@ -361,7 +359,8 @@ void FusionCore::predict_to(double timestamp_seconds) {
       ukf_.predict(config_.max_dt);
       t += config_.max_dt;
     }
-    // Fix 4: predict the remaining partial chunk: state was only propagated to t, not timestamp_seconds
+    // Fix 4: predict the remaining partial chunk: state was only propagated to t, not
+    // timestamp_seconds
     double dt_remaining = timestamp_seconds - t;
     if (dt_remaining > config_.min_dt) {
       ukf_.predict(dt_remaining);
@@ -373,17 +372,18 @@ void FusionCore::predict_to(double timestamp_seconds) {
   last_timestamp_ = timestamp_seconds;
 }
 
-void FusionCore::update_distance_traveled(double x, double y, double pre_update_speed) {
+void FusionCore::update_distance_traveled(double x, double y, double pre_update_speed)
+{
   if (!gnss_pos_set_) {
-    last_gnss_x_  = x;
-    last_gnss_y_  = y;
+    last_gnss_x_ = x;
+    last_gnss_y_ = y;
     gnss_pos_set_ = true;
     return;
   }
 
   double dx = x - last_gnss_x_;
   double dy = y - last_gnss_y_;
-  double dist = std::sqrt(dx*dx + dy*dy);
+  double dist = std::sqrt(dx * dx + dy * dy);
 
   // Minimum step size to filter GPS jitter: ignore sub-centimeter moves
   // This prevents GPS noise from accumulating fake distance
@@ -393,10 +393,11 @@ void FusionCore::update_distance_traveled(double x, double y, double pre_update_
   // Fix 8: use pre-update speed captured before apply_gnss_update().
   // Post-update velocity is already GNSS-corrected and not representative of
   // motion during the GPS step. Fall back to current state if not provided.
-  double state_speed = (pre_update_speed >= 0.0)
-    ? pre_update_speed
-    : std::sqrt(ukf_.state().x[VX] * ukf_.state().x[VX] +
-                ukf_.state().x[VY] * ukf_.state().x[VY]);
+  double state_speed =
+    (pre_update_speed >= 0.0)
+      ? pre_update_speed
+      : std::sqrt(
+          ukf_.state().x[VX] * ukf_.state().x[VX] + ukf_.state().x[VY] * ukf_.state().x[VY]);
 
   double yaw_rate = std::abs(ukf_.state().x[WZ]);
 
@@ -411,29 +412,30 @@ void FusionCore::update_distance_traveled(double x, double y, double pre_update_
   last_gnss_y_ = y;
 
   // Only validate heading from GPS track when motion quality is confirmed
-  if (!heading_validated_ &&
-      distance_traveled_ >= config_.heading_observable_distance) {
+  if (!heading_validated_ && distance_traveled_ >= config_.heading_observable_distance) {
     heading_validated_ = true;
-    heading_source_    = HeadingSource::GPS_TRACK;
+    heading_source_ = HeadingSource::GPS_TRACK;
   }
 }
 
 void FusionCore::update_imu(
-  double timestamp_seconds,
-  double wx, double wy, double wz,
-  double ax, double ay, double az
-) {
-  if (!initialized_)
-    throw std::runtime_error("FusionCore: update_imu() called before init()");
+  double timestamp_seconds, double wx, double wy, double wz, double ax, double ay, double az)
+{
+  if (!initialized_) throw std::runtime_error("FusionCore: update_imu() called before init()");
 
   predict_to(timestamp_seconds);
 
   sensors::ImuMeasurement z;
-  z[0] = wx; z[1] = wy; z[2] = wz;
-  z[3] = ax; z[4] = ay; z[5] = az;
+  z[0] = wx;
+  z[1] = wy;
+  z[2] = wz;
+  z[3] = ax;
+  z[4] = ay;
+  z[5] = az;
 
   // Use adaptive R if initialized, else config default
-  sensors::ImuNoiseMatrix R = adaptive_initialized_ ? R_imu_ : sensors::imu_noise_matrix(config_.imu);
+  sensors::ImuNoiseMatrix R =
+    adaptive_initialized_ ? R_imu_ : sensors::imu_noise_matrix(config_.imu);
 
   // During GPS coast mode, inflate R[WZ,WZ] so the encoder WZ dominates heading
   // rate estimation instead of the biased IMU gyro. The IMU still contributes to
@@ -447,7 +449,8 @@ void FusionCore::update_imu(
   if (config_.outlier_rejection) {
     sensors::ImuMeasurement innovation_pre;
     sensors::ImuNoiseMatrix S;
-    ukf_.predict_measurement<sensors::IMU_DIM>(z, sensors::imu_measurement_function, R, innovation_pre, S);
+    ukf_.predict_measurement<sensors::IMU_DIM>(
+      z, sensors::imu_measurement_function, R, innovation_pre, S);
     if (is_outlier<sensors::IMU_DIM>(innovation_pre, S, config_.outlier_threshold_imu)) {
       ++imu_outliers_;
       last_imu_time_ = timestamp_seconds;
@@ -460,7 +463,8 @@ void FusionCore::update_imu(
   last_imu_innovation_norm_ = innovation.norm();
 
   // Track innovation for adaptive noise estimation
-  adapt_R<sensors::IMU_DIM>(R_imu_, R_imu_floor_, imu_innovations_, innovation, config_.adaptive_imu);
+  adapt_R<sensors::IMU_DIM>(
+    R_imu_, R_imu_floor_, imu_innovations_, innovation, config_.adaptive_imu);
 
   // Save snapshot for delay compensation
   save_snapshot();
@@ -468,22 +472,23 @@ void FusionCore::update_imu(
   // Save IMU message for full replay retrodiction
   ImuBufferEntry entry;
   entry.timestamp = timestamp_seconds;
-  entry.wx = wx; entry.wy = wy; entry.wz = wz;
-  entry.ax = ax; entry.ay = ay; entry.az = az;
-  entry.R  = R;
+  entry.wx = wx;
+  entry.wy = wy;
+  entry.wz = wz;
+  entry.ax = ax;
+  entry.ay = ay;
+  entry.az = az;
+  entry.R = R;
   imu_buffer_.push_back(entry);
-  while ((int)imu_buffer_.size() > config_.imu_buffer_size)
-    imu_buffer_.pop_front();
+  while ((int)imu_buffer_.size() > config_.imu_buffer_size) imu_buffer_.pop_front();
 
   last_imu_time_ = timestamp_seconds;
   ++update_count_;
 }
 
 void FusionCore::update_imu_orientation(
-  double timestamp_seconds,
-  double roll, double pitch, double yaw,
-  const double orientation_cov[9]
-) {
+  double timestamp_seconds, double roll, double pitch, double yaw, const double orientation_cov[9])
+{
   if (!initialized_)
     throw std::runtime_error("FusionCore: update_imu_orientation() called before init()");
 
@@ -502,9 +507,11 @@ void FusionCore::update_imu_orientation(
     // via the Kalman cross-covariance; a 2D update eliminates the channel entirely.
     sensors::ImuRPNoiseMatrix R_rp;
     if (orientation_cov != nullptr) {
-      R_rp(0,0) = (orientation_cov[0] > 0.0) ? orientation_cov[0] : fallback.roll_noise  * fallback.roll_noise;
-      R_rp(1,1) = (orientation_cov[4] > 0.0) ? orientation_cov[4] : fallback.pitch_noise * fallback.pitch_noise;
-      R_rp(0,1) = R_rp(1,0) = 0.0;
+      R_rp(0, 0) =
+        (orientation_cov[0] > 0.0) ? orientation_cov[0] : fallback.roll_noise * fallback.roll_noise;
+      R_rp(1, 1) = (orientation_cov[4] > 0.0) ? orientation_cov[4]
+                                              : fallback.pitch_noise * fallback.pitch_noise;
+      R_rp(0, 1) = R_rp(1, 0) = 0.0;
     } else {
       R_rp = sensors::imu_rp_noise_matrix(fallback);
     }
@@ -515,7 +522,7 @@ void FusionCore::update_imu_orientation(
 
     if (config_.outlier_rejection) {
       sensors::ImuRPMeasurement innovation_pre;
-      sensors::ImuRPNoiseMatrix  S;
+      sensors::ImuRPNoiseMatrix S;
       ukf_.predict_measurement<sensors::IMU_RP_DIM>(
         z_rp, sensors::imu_rp_measurement_function, R_rp, innovation_pre, S);
       if (is_outlier<sensors::IMU_RP_DIM>(innovation_pre, S, config_.outlier_threshold_imu)) {
@@ -541,7 +548,8 @@ void FusionCore::update_imu_orientation(
       sensors::ImuOrientationNoiseMatrix S;
       ukf_.predict_measurement<sensors::IMU_ORIENTATION_DIM>(
         z, sensors::imu_orientation_measurement_function, R, innovation_pre, S);
-      if (is_outlier<sensors::IMU_ORIENTATION_DIM>(innovation_pre, S, config_.outlier_threshold_imu)) {
+      if (is_outlier<sensors::IMU_ORIENTATION_DIM>(
+            innovation_pre, S, config_.outlier_threshold_imu)) {
         ++imu_outliers_;
         last_imu_time_ = timestamp_seconds;
         return;
@@ -553,7 +561,8 @@ void FusionCore::update_imu_orientation(
       z, sensors::imu_orientation_measurement_function, R, IMU_ORIENT_ANGLE_DIMS);
 
     adapt_R<sensors::IMU_ORIENTATION_DIM>(
-      R_imu_orient_, R_imu_orient_floor_, imu_orient_innovations_, imu_orient_innovation, config_.adaptive_imu);
+      R_imu_orient_, R_imu_orient_floor_, imu_orient_innovations_, imu_orient_innovation,
+      config_.adaptive_imu);
   }
 
   // IMU orientation validates heading ONLY if the IMU has a magnetometer.
@@ -561,10 +570,9 @@ void FusionCore::update_imu_orientation(
   // heading reference. 9-axis IMUs with magnetometer give true heading.
   // peci1 fix: don't blindly trust IMU orientation as heading source.
   if (config_.imu_has_magnetometer) {
-    if (!heading_validated_ ||
-        heading_source_ == HeadingSource::GPS_TRACK) {
+    if (!heading_validated_ || heading_source_ == HeadingSource::GPS_TRACK) {
       heading_validated_ = true;
-      heading_source_    = HeadingSource::IMU_ORIENTATION;
+      heading_source_ = HeadingSource::IMU_ORIENTATION;
     }
   }
   // If no magnetometer: orientation still fused for roll/pitch accuracy,
@@ -575,31 +583,31 @@ void FusionCore::update_imu_orientation(
 }
 
 void FusionCore::update_encoder(
-  double timestamp_seconds,
-  double vx, double vy, double wz,
-  double var_vx,
-  double var_vy,
-  double var_wz
-) {
-  if (!initialized_)
-    throw std::runtime_error("FusionCore: update_encoder() called before init()");
+  double timestamp_seconds, double vx, double vy, double wz, double var_vx, double var_vy,
+  double var_wz)
+{
+  if (!initialized_) throw std::runtime_error("FusionCore: update_encoder() called before init()");
 
   predict_to(timestamp_seconds);
 
   sensors::EncoderMeasurement z;
-  z[0] = vx; z[1] = vy; z[2] = wz;
+  z[0] = vx;
+  z[1] = vy;
+  z[2] = wz;
 
   // Use message covariance when provided, else adaptive R, else config default
-  sensors::EncoderNoiseMatrix R = adaptive_initialized_ ? R_encoder_ : sensors::encoder_noise_matrix(config_.encoder);
-  if (var_vx > 0.0) R(0,0) = var_vx;
-  if (var_vy > 0.0) R(1,1) = var_vy;
-  if (var_wz > 0.0) R(2,2) = var_wz;
+  sensors::EncoderNoiseMatrix R =
+    adaptive_initialized_ ? R_encoder_ : sensors::encoder_noise_matrix(config_.encoder);
+  if (var_vx > 0.0) R(0, 0) = var_vx;
+  if (var_vy > 0.0) R(1, 1) = var_vy;
+  if (var_wz > 0.0) R(2, 2) = var_wz;
 
   // Mahalanobis outlier rejection for encoder
   if (config_.outlier_rejection) {
     sensors::EncoderMeasurement innovation_pre;
     sensors::EncoderNoiseMatrix S;
-    ukf_.predict_measurement<sensors::ENCODER_DIM>(z, sensors::encoder_measurement_function, R, innovation_pre, S);
+    ukf_.predict_measurement<sensors::ENCODER_DIM>(
+      z, sensors::encoder_measurement_function, R, innovation_pre, S);
     if (is_outlier<sensors::ENCODER_DIM>(innovation_pre, S, config_.outlier_threshold_enc)) {
       ++enc_outliers_;
       last_encoder_time_ = timestamp_seconds;
@@ -614,7 +622,8 @@ void FusionCore::update_encoder(
   // Track innovation for adaptive noise estimation
   // Only adapt axes where message covariance was not provided
   if (var_vx <= 0.0 && var_vy <= 0.0 && var_wz <= 0.0) {
-    adapt_R<sensors::ENCODER_DIM>(R_encoder_, R_encoder_floor_, encoder_innovations_, innovation, config_.adaptive_encoder);
+    adapt_R<sensors::ENCODER_DIM>(
+      R_encoder_, R_encoder_floor_, encoder_innovations_, innovation, config_.adaptive_encoder);
   }
 
   if (last_encoder_time_ >= 0.0) {
@@ -628,7 +637,8 @@ void FusionCore::update_encoder(
   ++update_count_;
 }
 
-void FusionCore::update_ground_constraint(double timestamp_seconds) {
+void FusionCore::update_ground_constraint(double timestamp_seconds)
+{
   if (!initialized_) return;
 
   // Force a minimal predict step so Q is injected into P before this update.
@@ -648,14 +658,14 @@ void FusionCore::update_ground_constraint(double timestamp_seconds) {
   // On rough terrain, VZ innovations grow and R_vz_ inflates automatically.
   // On flat ground, it relaxes back to the floor (config value) over ~1 second.
   Eigen::Matrix<double, 1, 1> R_vz;
-  R_vz(0,0) = adaptive_initialized_
-    ? R_vz_(0,0)
-    : (config_.ground_constraint_vz_sigma * config_.ground_constraint_vz_sigma);
+  R_vz(0, 0) = adaptive_initialized_
+                 ? R_vz_(0, 0)
+                 : (config_.ground_constraint_vz_sigma * config_.ground_constraint_vz_sigma);
 
   auto vz_innovation = ukf_.update<sensors::GROUND_CONSTRAINT_DIM>(
     z, sensors::ground_constraint_measurement_function, R_vz);
-  adapt_R<1>(R_vz_, R_vz_floor_, vz_innovations_, vz_innovation,
-             config_.adaptive_ground_constraint);
+  adapt_R<1>(
+    R_vz_, R_vz_floor_, vz_innovations_, vz_innovation, config_.adaptive_ground_constraint);
 
   // ── AZ = 0: body-frame vertical acceleration must be zero for ground robots.
   // Without this, a mismatch between the IMU's local gravity and the WGS84
@@ -669,18 +679,18 @@ void FusionCore::update_ground_constraint(double timestamp_seconds) {
   z_az[0] = 0.0;
 
   Eigen::Matrix<double, 1, 1> R_az;
-  R_az(0,0) = adaptive_initialized_
-    ? R_az_(0,0)
-    : (config_.ground_constraint_az_sigma * config_.ground_constraint_az_sigma);
+  R_az(0, 0) = adaptive_initialized_
+                 ? R_az_(0, 0)
+                 : (config_.ground_constraint_az_sigma * config_.ground_constraint_az_sigma);
 
-  auto h_az = [](const StateVector& x) -> Eigen::Matrix<double, 1, 1> {
+  auto h_az = [](const StateVector & x) -> Eigen::Matrix<double, 1, 1> {
     Eigen::Matrix<double, 1, 1> m;
     m[0] = x[AZ];
     return m;
   };
   auto az_innovation = ukf_.update<1>(z_az, h_az, R_az);
-  adapt_R<1>(R_az_, R_az_floor_, az_innovations_, az_innovation,
-             config_.adaptive_ground_constraint);
+  adapt_R<1>(
+    R_az_, R_az_floor_, az_innovations_, az_innovation, config_.adaptive_ground_constraint);
 
   // ── Z position = 0: flat-terrain pseudo-measurement ─────────────────────
   // When enabled, tells the filter the robot's altitude above its starting
@@ -691,8 +701,8 @@ void FusionCore::update_ground_constraint(double timestamp_seconds) {
     Eigen::Matrix<double, 1, 1> z_pos;
     z_pos[0] = 0.0;
     Eigen::Matrix<double, 1, 1> R_zpos;
-    R_zpos(0,0) = config_.ground_z_position_sigma * config_.ground_z_position_sigma;
-    auto h_zpos = [](const StateVector& x) -> Eigen::Matrix<double, 1, 1> {
+    R_zpos(0, 0) = config_.ground_z_position_sigma * config_.ground_z_position_sigma;
+    auto h_zpos = [](const StateVector & x) -> Eigen::Matrix<double, 1, 1> {
       Eigen::Matrix<double, 1, 1> m;
       m[0] = x[Z];
       return m;
@@ -701,7 +711,8 @@ void FusionCore::update_ground_constraint(double timestamp_seconds) {
   }
 }
 
-void FusionCore::update_zupt(double timestamp_seconds, double noise_sigma) {
+void FusionCore::update_zupt(double timestamp_seconds, double noise_sigma)
+{
   if (!initialized_) return;
 
   predict_to(timestamp_seconds);
@@ -715,19 +726,16 @@ void FusionCore::update_zupt(double timestamp_seconds, double noise_sigma) {
 
   sensors::EncoderNoiseMatrix R = sensors::EncoderNoiseMatrix::Zero();
   double var = noise_sigma * noise_sigma;
-  R(0,0) = var;
-  R(1,1) = var;
-  R(2,2) = var;
+  R(0, 0) = var;
+  R(1, 1) = var;
+  R(2, 2) = var;
 
   ukf_.update<sensors::ENCODER_DIM>(z, sensors::zupt_measurement_function, R);
 }
 
-bool FusionCore::update_gnss(
-  double timestamp_seconds,
-  const sensors::GnssFix& fix
-) {
-  if (!initialized_)
-    throw std::runtime_error("FusionCore: update_gnss() called before init()");
+bool FusionCore::update_gnss(double timestamp_seconds, const sensors::GnssFix & fix)
+{
+  if (!initialized_) throw std::runtime_error("FusionCore: update_gnss() called before init()");
 
   // Always populate what we know from the fix before any gate check
   gnss_debug_.hdop               = fix.hdop;
@@ -764,8 +772,7 @@ bool FusionCore::update_gnss(
     bool applied = apply_delayed_measurement(timestamp_seconds, [&]() {
       predict_to(timestamp_seconds);
       pre_update_speed_delayed = std::sqrt(
-        ukf_.state().x[VX] * ukf_.state().x[VX] +
-        ukf_.state().x[VY] * ukf_.state().x[VY]);
+        ukf_.state().x[VX] * ukf_.state().x[VX] + ukf_.state().x[VY] * ukf_.state().x[VY]);
       gnss_fused = apply_gnss_update(timestamp_seconds, fix);
     });
     if (!applied) {
@@ -780,9 +787,10 @@ bool FusionCore::update_gnss(
   }
 
   predict_to(timestamp_seconds);
-  double pre_update_speed = std::sqrt(
-    ukf_.state().x[VX] * ukf_.state().x[VX] +
-    ukf_.state().x[VY] * ukf_.state().x[VY]);
+  // Fix 8: capture speed BEFORE gnss update: post-update velocity is corrected
+  // and not representative of motion during this GPS step.
+  double pre_update_speed =
+    std::sqrt(ukf_.state().x[VX] * ukf_.state().x[VX] + ukf_.state().x[VY] * ukf_.state().x[VY]);
   if (!apply_gnss_update(timestamp_seconds, fix)) return false;
   update_distance_traveled(fix.x, fix.y, pre_update_speed);
   last_gnss_time_ = timestamp_seconds;
@@ -791,9 +799,8 @@ bool FusionCore::update_gnss(
 }
 
 void FusionCore::reset_gps_rotation_heading_window(
-  double timestamp_seconds,
-  const sensors::GnssFix& fix,
-  const sensors::GnssPosNoiseMatrix& R_meas)
+  double timestamp_seconds, const sensors::GnssFix & fix,
+  const sensors::GnssPosNoiseMatrix & R_meas)
 {
   gps_rotation_hdg_window_.set = true;
   gps_rotation_hdg_window_.timestamp = timestamp_seconds;
@@ -804,16 +811,23 @@ void FusionCore::reset_gps_rotation_heading_window(
   gps_rotation_hdg_window_.encoder_distance = encoder_distance_;
 }
 
+void FusionCore::reset_gps_track_heading_reference(const sensors::GnssFix & fix)
+{
+  last_hdg_fix_x_ = fix.x;
+  last_hdg_fix_y_ = fix.y;
+  last_hdg_fix_yaw_ = ukf_.state().yaw();
+  hdg_fix_set_ = true;
+}
+
 bool FusionCore::try_fuse_gps_rotation_heading(
-  double timestamp_seconds,
-  const sensors::GnssFix& fix,
-  const sensors::GnssPosNoiseMatrix& R_meas)
+  double timestamp_seconds, const sensors::GnssFix & fix,
+  const sensors::GnssPosNoiseMatrix & R_meas)
 {
   if (!config_.gps_rotation_heading_enabled || fix.lever_arm.is_zero()) return false;
 
-  if (heading_validated_ &&
-      heading_source_ != HeadingSource::GPS_TRACK &&
-      heading_source_ != HeadingSource::GPS_ROTATION) {
+  if (
+    heading_validated_ && heading_source_ != HeadingSource::GPS_TRACK &&
+    heading_source_ != HeadingSource::GPS_ROTATION) {
     return false;
   }
 
@@ -825,9 +839,10 @@ bool FusionCore::try_fuse_gps_rotation_heading(
     return false;
   }
 
-  if (config_.gps_rotation_heading_max_window_s > 0.0 &&
-      timestamp_seconds - gps_rotation_hdg_window_.timestamp >
-        config_.gps_rotation_heading_max_window_s) {
+  if (
+    config_.gps_rotation_heading_max_window_s > 0.0 &&
+    timestamp_seconds - gps_rotation_hdg_window_.timestamp >
+      config_.gps_rotation_heading_max_window_s) {
     reset_gps_rotation_heading_window(timestamp_seconds, fix, R_meas);
     return false;
   }
@@ -845,14 +860,12 @@ bool FusionCore::try_fuse_gps_rotation_heading(
   const double c = std::cos(delta_yaw);
   const double s = std::sin(delta_yaw);
   const Eigen::Vector2d arc_body(
-    (c - 1.0) * lever.x() - s * lever.y(),
-    s * lever.x() + (c - 1.0) * lever.y());
+    (c - 1.0) * lever.x() - s * lever.y(), s * lever.x() + (c - 1.0) * lever.y());
   const double arc_len = arc_body.norm();
   if (arc_len < config_.gps_rotation_heading_min_arc_baseline) return false;
 
   const Eigen::Vector2d observed(
-    fix.x - gps_rotation_hdg_window_.fix_x,
-    fix.y - gps_rotation_hdg_window_.fix_y);
+    fix.x - gps_rotation_hdg_window_.fix_x, fix.y - gps_rotation_hdg_window_.fix_y);
   const double observed_len = observed.norm();
   if (observed_len < 1e-6) return false;
 
@@ -862,8 +875,7 @@ bool FusionCore::try_fuse_gps_rotation_heading(
   const double sigma_floor = config_.gps_rotation_heading_sigma_floor;
   const double delta_yaw_sigma = config_.gps_rotation_heading_delta_yaw_sigma;
   const double sigma_hdg = std::sqrt(
-    lateral_var / (arc_len * arc_len) +
-    delta_yaw_sigma * delta_yaw_sigma +
+    lateral_var / (arc_len * arc_len) + delta_yaw_sigma * delta_yaw_sigma +
     sigma_floor * sigma_floor);
 
   if (!std::isfinite(sigma_hdg) || sigma_hdg > config_.gps_rotation_heading_max_sigma) {
@@ -878,7 +890,7 @@ bool FusionCore::try_fuse_gps_rotation_heading(
   z_hdg[0] = yaw_current_est;
 
   sensors::GnssHdgNoiseMatrix R_hdg;
-  R_hdg(0,0) = sigma_hdg * sigma_hdg;
+  R_hdg(0, 0) = sigma_hdg * sigma_hdg;
 
   constexpr unsigned int HDG_ANGLE_DIMS = 0b1;
 
@@ -887,8 +899,7 @@ bool FusionCore::try_fuse_gps_rotation_heading(
     sensors::GnssHdgMeasurement innov_pre;
     sensors::GnssHdgNoiseMatrix S_pre;
     ukf_.predict_measurement<sensors::GNSS_HDG_DIM>(
-      z_hdg, sensors::gnss_hdg_measurement_function, R_hdg,
-      innov_pre, S_pre, HDG_ANGLE_DIMS);
+      z_hdg, sensors::gnss_hdg_measurement_function, R_hdg, innov_pre, S_pre, HDG_ANGLE_DIMS);
     fuse = !is_outlier<sensors::GNSS_HDG_DIM>(innov_pre, S_pre, config_.outlier_threshold_hdg);
   }
 
@@ -904,9 +915,9 @@ bool FusionCore::try_fuse_gps_rotation_heading(
   gps_rotation_hdg_fused_ = true;
   last_heading_sigma_ = sigma_hdg;
 
-  if (!heading_validated_ ||
-      heading_source_ == HeadingSource::GPS_TRACK ||
-      heading_source_ == HeadingSource::GPS_ROTATION) {
+  if (
+    !heading_validated_ || heading_source_ == HeadingSource::GPS_TRACK ||
+    heading_source_ == HeadingSource::GPS_ROTATION) {
     heading_validated_ = true;
     heading_source_ = HeadingSource::GPS_ROTATION;
   }
@@ -915,9 +926,7 @@ bool FusionCore::try_fuse_gps_rotation_heading(
   return true;
 }
 
-bool FusionCore::apply_gnss_update(
-  double timestamp_seconds,
-  const sensors::GnssFix& fix)
+bool FusionCore::apply_gnss_update(double timestamp_seconds, const sensors::GnssFix & fix)
 {
   sensors::GnssPosMeasurement z;
   z[0] = fix.x;
@@ -942,9 +951,10 @@ bool FusionCore::apply_gnss_update(
   // When GPS is consistently biased (multipath, foliage), R_gnss_ reflects the true error
   // magnitude and Kalman gain shrinks accordingly. Full-covariance fixes are left untouched:
   // the receiver already knows its own noise.
-  if (adaptive_initialized_ && config_.adaptive_gnss && !fix.has_full_covariance && gnss_innovations_.ready()) {
-    for (int i = 0; i < 3; ++i)
-      R(i,i) = std::max(R(i,i), R_gnss_(i,i));
+  if (
+    adaptive_initialized_ && config_.adaptive_gnss && !fix.has_full_covariance &&
+    gnss_innovations_.ready()) {
+    for (int i = 0; i < 3; ++i) R(i, i) = std::max(R(i, i), R_gnss_(i, i));
   }
 
   double heading_sigma_rad = compute_heading_sigma_rad();
@@ -956,10 +966,9 @@ bool FusionCore::apply_gnss_update(
   bool use_lever_arm = !fix.lever_arm.is_zero() && heading_reliable;
   gnss_debug_.lever_arm_used = use_lever_arm;
 
-  auto h_gnss = use_lever_arm
-    ? sensors::gnss_pos_measurement_function_with_lever_arm(fix.lever_arm)
-    : std::function<sensors::GnssPosMeasurement(const StateVector&)>(
-        sensors::gnss_pos_measurement_function);
+  auto h_gnss = use_lever_arm ? sensors::gnss_pos_measurement_function_with_lever_arm(fix.lever_arm)
+                              : std::function<sensors::GnssPosMeasurement(const StateVector &)>(
+                                  sensors::gnss_pos_measurement_function);
 
   if (config_.outlier_rejection) {
     sensors::GnssPosMeasurement innovation_pre;
@@ -985,8 +994,13 @@ bool FusionCore::apply_gnss_update(
           ukf_.set_position_noise_scale(config_.gnss_coast_q_factor);
           ukf_.set_gyro_bias_noise_scale(config_.gnss_coast_q_bias_factor);
         }
-        if (config_.gnss_recovery_rejection_n > 0 &&
-            gnss_consecutive_rejects_ == config_.gnss_recovery_rejection_n) {
+        // When coast Q inflation alone isn't enough (filter drifted before the
+        // cascade started), inflate P[x,x] and P[y,y] directly. This fires once
+        // (== not >=) so the gate opens on the next fix via a proper Bayesian
+        // update, not a hard reset. Cross-covariances are untouched.
+        if (
+          config_.gnss_recovery_rejection_n > 0 &&
+          gnss_consecutive_rejects_ == config_.gnss_recovery_rejection_n) {
           double s2 = config_.gnss_p_inflate_sigma * config_.gnss_p_inflate_sigma;
           ukf_.inflate_position_covariance(s2);
         }
@@ -1016,29 +1030,43 @@ bool FusionCore::apply_gnss_update(
   last_gnss_innovation_norm_     = innovation.norm();
 
   // Track innovation for adaptive GNSS noise estimation
-  adapt_R<sensors::GNSS_POS_DIM>(R_gnss_, R_gnss_floor_, gnss_innovations_, innovation, config_.adaptive_gnss);
+  adapt_R<sensors::GNSS_POS_DIM>(
+    R_gnss_, R_gnss_floor_, gnss_innovations_, innovation, config_.adaptive_gnss);
 
   try_fuse_gps_rotation_heading(timestamp_seconds, fix, R_meas);
 
   // GPS track heading fusion: fuse the displacement bearing as a yaw update.
   // This is the same mechanism navsat_transform uses for RL-EKF and directly
   // corrects heading from GPS geometry rather than relying on gyro bias estimation.
-  // Displacement accumulates across multiple GPS fixes (using a separate reference
-  // position that only advances when a heading fusion fires) so the baseline is
-  // always large enough for the uncertainty to be meaningful.
-  if (config_.gps_track_heading_enabled) {
+  // Displacement accumulates across multiple GPS fixes in a straight-motion window
+  // so the baseline is large enough and the bearing represents robot heading.
+  if (
+    config_.gps_track_heading_enabled &&
+    (!heading_validated_ || heading_source_ == HeadingSource::GPS_TRACK ||
+     heading_source_ == HeadingSource::GPS_ROTATION)) {
     if (!hdg_fix_set_) {
       // Initialize reference on first accepted fix; no heading yet.
-      last_hdg_fix_x_ = fix.x;
-      last_hdg_fix_y_ = fix.y;
-      hdg_fix_set_    = true;
+      reset_gps_track_heading_reference(fix);
     } else {
-      double dx   = fix.x - last_hdg_fix_x_;
-      double dy   = fix.y - last_hdg_fix_y_;
-      double dist = std::sqrt(dx*dx + dy*dy);
+      const double current_yaw = ukf_.state().yaw();
+      const double forward_speed = ukf_.state().x[VX];
+      const double yaw_rate = std::abs(ukf_.state().x[WZ]);
+      const double yaw_delta = std::abs(normalize_angle(current_yaw - last_hdg_fix_yaw_));
+
+      if (
+        forward_speed < config_.gps_track_heading_min_speed ||
+        yaw_rate > config_.gps_track_heading_max_yaw_rate ||
+        yaw_delta > config_.gps_track_heading_max_yaw_delta) {
+        reset_gps_track_heading_reference(fix);
+        return true;
+      }
+
+      double dx = fix.x - last_hdg_fix_x_;
+      double dy = fix.y - last_hdg_fix_y_;
+      double dist = std::sqrt(dx * dx + dy * dy);
 
       if (dist >= config_.gps_track_heading_min_dist) {
-        double sigma_xy  = std::sqrt((R_meas(0,0) + R_meas(1,1)) * 0.5);
+        double sigma_xy = std::sqrt((R_meas(0, 0) + R_meas(1, 1)) * 0.5);
         double sigma_hdg = sigma_xy / dist;
 
         if (sigma_hdg <= config_.gps_track_heading_max_sigma) {
@@ -1046,7 +1074,7 @@ bool FusionCore::apply_gnss_update(
           z_hdg[0] = std::atan2(dy, dx);
 
           sensors::GnssHdgNoiseMatrix R_hdg;
-          R_hdg(0,0) = sigma_hdg * sigma_hdg;
+          R_hdg(0, 0) = sigma_hdg * sigma_hdg;
 
           constexpr unsigned int HDG_ANGLE_DIMS = 0b1;
 
@@ -1061,8 +1089,10 @@ bool FusionCore::apply_gnss_update(
             sensors::GnssHdgMeasurement innov_pre;
             sensors::GnssHdgNoiseMatrix S_pre;
             ukf_.predict_measurement<sensors::GNSS_HDG_DIM>(
-              z_hdg, sensors::gnss_hdg_measurement_function, R_hdg, innov_pre, S_pre, HDG_ANGLE_DIMS);
-            fuse = !is_outlier<sensors::GNSS_HDG_DIM>(innov_pre, S_pre, config_.outlier_threshold_hdg);
+              z_hdg, sensors::gnss_hdg_measurement_function, R_hdg, innov_pre, S_pre,
+              HDG_ANGLE_DIMS);
+            fuse =
+              !is_outlier<sensors::GNSS_HDG_DIM>(innov_pre, S_pre, config_.outlier_threshold_hdg);
           }
 
           if (fuse) {
@@ -1073,7 +1103,7 @@ bool FusionCore::apply_gnss_update(
 
             if (!heading_validated_) {
               heading_validated_ = true;
-              heading_source_    = HeadingSource::GPS_TRACK;
+              heading_source_ = HeadingSource::GPS_TRACK;
             }
           }
 
@@ -1082,8 +1112,7 @@ bool FusionCore::apply_gnss_update(
           // advance; let the displacement keep accumulating until the baseline
           // is long enough for a reliable heading. With NCLT GPS (σ=3m) and
           // max_sigma=0.4 rad, fusion first fires at ~7.5m of displacement.
-          last_hdg_fix_x_ = fix.x;
-          last_hdg_fix_y_ = fix.y;
+          reset_gps_track_heading_reference(fix);
         }
         // else: sigma too high, keep accumulating displacement
       }
@@ -1093,10 +1122,8 @@ bool FusionCore::apply_gnss_update(
   return true;
 }
 
-bool FusionCore::update_gnss_heading(
-  double timestamp_seconds,
-  const sensors::GnssHeading& heading
-) {
+bool FusionCore::update_gnss_heading(double timestamp_seconds, const sensors::GnssHeading & heading)
+{
   if (!initialized_)
     throw std::runtime_error("FusionCore: update_gnss_heading() called before init()");
 
@@ -1107,8 +1134,7 @@ bool FusionCore::update_gnss_heading(
   sensors::GnssHdgMeasurement z;
   z[0] = heading.heading_rad;
 
-  sensors::GnssHdgNoiseMatrix R =
-    sensors::gnss_hdg_noise_matrix(config_.gnss, heading);
+  sensors::GnssHdgNoiseMatrix R = sensors::gnss_hdg_noise_matrix(config_.gnss, heading);
 
   // Dimension 0 (heading) is an angle: wrap z_diff across ±π boundary
   constexpr unsigned int HDG_ANGLE_DIMS = 0b1;  // bit 0 = heading
@@ -1125,67 +1151,64 @@ bool FusionCore::update_gnss_heading(
     }
   }
 
-  ukf_.update<sensors::GNSS_HDG_DIM>(
-    z, sensors::gnss_hdg_measurement_function, R, HDG_ANGLE_DIMS);
-  last_heading_sigma_ = std::sqrt(R(0,0));
+  ukf_.update<sensors::GNSS_HDG_DIM>(z, sensors::gnss_hdg_measurement_function, R, HDG_ANGLE_DIMS);
+  last_heading_sigma_ = std::sqrt(R(0, 0));
 
   // Dual antenna heading is the strongest possible heading validation
   // Override any weaker source
   heading_validated_ = true;
-  heading_source_    = HeadingSource::DUAL_ANTENNA;
+  heading_source_ = HeadingSource::DUAL_ANTENNA;
 
   last_gnss_time_ = timestamp_seconds;
   ++update_count_;
   return true;
 }
 
-const State& FusionCore::get_state() const {
+const State & FusionCore::get_state() const
+{
   return ukf_.state();
 }
 
-FusionCoreStatus FusionCore::get_status() const {
+FusionCoreStatus FusionCore::get_status() const
+{
   FusionCoreStatus status;
-  status.initialized  = initialized_;
+  status.initialized = initialized_;
   status.update_count = update_count_;
 
   if (!initialized_) return status;
 
   const double stale = config_.stale_timeout;
 
-  status.imu_health =
-    last_imu_time_ < 0.0 ? SensorHealth::NOT_INIT :
-    (last_timestamp_ - last_imu_time_) > stale ? SensorHealth::STALE :
-    SensorHealth::OK;
+  status.imu_health = last_imu_time_ < 0.0                         ? SensorHealth::NOT_INIT
+                      : (last_timestamp_ - last_imu_time_) > stale ? SensorHealth::STALE
+                                                                   : SensorHealth::OK;
 
-  status.encoder_health =
-    last_encoder_time_ < 0.0 ? SensorHealth::NOT_INIT :
-    (last_timestamp_ - last_encoder_time_) > stale ? SensorHealth::STALE :
-    SensorHealth::OK;
+  status.encoder_health = last_encoder_time_ < 0.0                         ? SensorHealth::NOT_INIT
+                          : (last_timestamp_ - last_encoder_time_) > stale ? SensorHealth::STALE
+                                                                           : SensorHealth::OK;
 
-  status.gnss_health =
-    last_gnss_time_ < 0.0 ? SensorHealth::NOT_INIT :
-    (last_timestamp_ - last_gnss_time_) > stale ? SensorHealth::STALE :
-    SensorHealth::OK;
+  status.gnss_health = last_gnss_time_ < 0.0                         ? SensorHealth::NOT_INIT
+                       : (last_timestamp_ - last_gnss_time_) > stale ? SensorHealth::STALE
+                                                                     : SensorHealth::OK;
 
-  const StateMatrix& P = ukf_.state().P;
-  status.position_uncertainty = P(0,0) + P(1,1) + P(2,2);
+  const StateMatrix & P = ukf_.state().P;
+  status.position_uncertainty = P(0, 0) + P(1, 1) + P(2, 2);
 
   // Heading observability
   status.heading_validated = heading_validated_;
-  status.heading_source    = heading_source_;
+  status.heading_source = heading_source_;
   status.distance_traveled = distance_traveled_;
   status.last_heading_sigma = last_heading_sigma_;
 
-  status.vslam_health =
-    last_vslam_time_ < 0.0 ? SensorHealth::NOT_INIT :
-    (last_timestamp_ - last_vslam_time_) > stale ? SensorHealth::STALE :
-    SensorHealth::OK;
+  status.vslam_health = last_vslam_time_ < 0.0                         ? SensorHealth::NOT_INIT
+                        : (last_timestamp_ - last_vslam_time_) > stale ? SensorHealth::STALE
+                                                                       : SensorHealth::OK;
 
   // Outlier rejection counters
-  status.gnss_outliers  = gnss_outliers_;
-  status.imu_outliers   = imu_outliers_;
-  status.enc_outliers   = enc_outliers_;
-  status.hdg_outliers   = hdg_outliers_;
+  status.gnss_outliers = gnss_outliers_;
+  status.imu_outliers = imu_outliers_;
+  status.enc_outliers = enc_outliers_;
+  status.hdg_outliers = hdg_outliers_;
   status.vslam_outliers = vslam_outliers_;
 
   // Innovation norms from last accepted update per sensor
@@ -1205,12 +1228,9 @@ FusionCoreStatus FusionCore::get_status() const {
   return status;
 }
 
-bool FusionCore::update_pose(
-  double timestamp_seconds,
-  const sensors::VslamPose& pose)
+bool FusionCore::update_pose(double timestamp_seconds, const sensors::VslamPose & pose)
 {
-  if (!initialized_)
-    throw std::runtime_error("FusionCore: update_pose() called before init()");
+  if (!initialized_) throw std::runtime_error("FusionCore: update_pose() called before init()");
 
   bool is_delayed = (last_timestamp_ - timestamp_seconds) > config_.min_dt;
 
@@ -1220,8 +1240,12 @@ bool FusionCore::update_pose(
       predict_to(timestamp_seconds);
 
       sensors::VslamPoseMeasurement z;
-      z[0] = pose.x; z[1] = pose.y; z[2] = pose.z;
-      z[3] = pose.roll; z[4] = pose.pitch; z[5] = pose.yaw;
+      z[0] = pose.x;
+      z[1] = pose.y;
+      z[2] = pose.z;
+      z[3] = pose.roll;
+      z[4] = pose.pitch;
+      z[5] = pose.yaw;
 
       sensors::VslamPoseNoiseMatrix R = sensors::vslam_pose_noise_matrix(config_.vslam, pose);
 
@@ -1241,7 +1265,8 @@ bool FusionCore::update_pose(
 
       auto innovation = ukf_.update<sensors::VSLAM_POSE_DIM>(
         z, sensors::vslam_pose_measurement_function, R, VSLAM_ANGLE_DIMS);
-      adapt_R<sensors::VSLAM_POSE_DIM>(R_vslam_, R_vslam_floor_, vslam_innovations_, innovation, false);
+      adapt_R<sensors::VSLAM_POSE_DIM>(
+        R_vslam_, R_vslam_floor_, vslam_innovations_, innovation, false);
       fused = true;
     });
     if (!applied || !fused) return false;
@@ -1254,8 +1279,12 @@ bool FusionCore::update_pose(
   predict_to(timestamp_seconds);
 
   sensors::VslamPoseMeasurement z;
-  z[0] = pose.x; z[1] = pose.y; z[2] = pose.z;
-  z[3] = pose.roll; z[4] = pose.pitch; z[5] = pose.yaw;
+  z[0] = pose.x;
+  z[1] = pose.y;
+  z[2] = pose.z;
+  z[3] = pose.roll;
+  z[4] = pose.pitch;
+  z[5] = pose.yaw;
 
   sensors::VslamPoseNoiseMatrix R = sensors::vslam_pose_noise_matrix(config_.vslam, pose);
 
@@ -1282,15 +1311,14 @@ bool FusionCore::update_pose(
   ++update_count_;
 
   // Validate heading from VSLAM travel (same path as GPS track)
-  if (!heading_validated_ &&
-      heading_source_ == HeadingSource::NONE) {
+  if (!heading_validated_ && heading_source_ == HeadingSource::NONE) {
     if (distance_traveled_ >= config_.heading_observable_distance) {
       heading_validated_ = true;
-      heading_source_    = HeadingSource::GPS_TRACK;
+      heading_source_ = HeadingSource::GPS_TRACK;
     }
   }
 
   return true;
 }
 
-} // namespace fusioncore
+}  // namespace fusioncore

--- a/fusioncore_core/src/ukf.cpp
+++ b/fusioncore_core/src/ukf.cpp
@@ -217,6 +217,67 @@ Eigen::Matrix<double, z_dim, 1> UKF::update(
 }
 
 template <int z_dim>
+Eigen::Matrix<double, z_dim, 1> UKF::update_masked(
+  const Eigen::Matrix<double, z_dim, 1>& z,
+  const std::function<Eigen::Matrix<double, z_dim, 1>(const StateVector&)>& h,
+  const Eigen::Matrix<double, z_dim, z_dim>& R,
+  const std::array<bool, STATE_DIM>& state_update_mask,
+  unsigned int angle_dims
+) {
+  if (!initialized_)
+    throw std::runtime_error("FusionCore: update_masked() called before init()");
+
+  using ZVector   = Eigen::Matrix<double, z_dim, 1>;
+  using ZMatrix   = Eigen::Matrix<double, z_dim, z_dim>;
+  using PxzMatrix = Eigen::Matrix<double, STATE_DIM, z_dim>;
+
+  Eigen::MatrixXd sigma = generate_sigma_points();
+  int n_sigma = 2 * n_aug_ + 1;
+
+  Eigen::Matrix<double, z_dim, Eigen::Dynamic> sigma_z(z_dim, n_sigma);
+  for (int i = 0; i < n_sigma; ++i)
+    sigma_z.col(i) = h(sigma.col(i));
+
+  ZVector z_pred = ZVector::Zero();
+  for (int i = 0; i < n_sigma; ++i)
+    z_pred += Wm_[i] * sigma_z.col(i);
+
+  ZMatrix   S   = R;
+  PxzMatrix Pxz = PxzMatrix::Zero();
+  for (int i = 0; i < n_sigma; ++i) {
+    ZVector z_diff = sigma_z.col(i) - z_pred;
+    for (int d = 0; d < z_dim; ++d)
+      if (angle_dims & (1u << d)) z_diff[d] = normalize_angle(z_diff[d]);
+    StateVector x_diff = sigma.col(i) - state_.x;
+    S   += Wc_[i] * z_diff * z_diff.transpose();
+    Pxz += Wc_[i] * x_diff * z_diff.transpose();
+  }
+
+  ZVector innovation = z - z_pred;
+  for (int d = 0; d < z_dim; ++d)
+    if (angle_dims & (1u << d)) innovation[d] = normalize_angle(innovation[d]);
+
+  auto S_ldlt = S.ldlt();
+  PxzMatrix K = S_ldlt.solve(Pxz.transpose()).transpose();
+  for (int i = 0; i < STATE_DIM; ++i) {
+    if (!state_update_mask[i]) K.row(i).setZero();
+  }
+
+  state_.x = normalize_state(state_.x + K * innovation);
+  state_.P -= K * S * K.transpose();
+  state_.P = (state_.P + state_.P.transpose()) * 0.5;
+  for (int i = 0; i < STATE_DIM; ++i) {
+    if (state_update_mask[i]) continue;
+    for (int j = 0; j < STATE_DIM; ++j) {
+      if (!state_update_mask[j]) continue;
+      state_.P(i, j) = 0.0;
+      state_.P(j, i) = 0.0;
+    }
+  }
+  return innovation;
+}
+
+template <int z_dim>
 void UKF::predict_measurement(
   const Eigen::Matrix<double, z_dim, 1>& z,
   const std::function<Eigen::Matrix<double, z_dim, 1>(const StateVector&)>& h,
@@ -333,6 +394,35 @@ template Eigen::Matrix<double, 6, 1> UKF::update<6>(
   const Eigen::Matrix<double, 6, 1>&,
   const std::function<Eigen::Matrix<double, 6, 1>(const StateVector&)>&,
   const Eigen::Matrix<double, 6, 6>&,
+  unsigned int
+);
+
+template Eigen::Matrix<double, 2, 1> UKF::update_masked<2>(
+  const Eigen::Matrix<double, 2, 1>&,
+  const std::function<Eigen::Matrix<double, 2, 1>(const StateVector&)>&,
+  const Eigen::Matrix<double, 2, 2>&,
+  const std::array<bool, STATE_DIM>&,
+  unsigned int
+);
+template Eigen::Matrix<double, 1, 1> UKF::update_masked<1>(
+  const Eigen::Matrix<double, 1, 1>&,
+  const std::function<Eigen::Matrix<double, 1, 1>(const StateVector&)>&,
+  const Eigen::Matrix<double, 1, 1>&,
+  const std::array<bool, STATE_DIM>&,
+  unsigned int
+);
+template Eigen::Matrix<double, 3, 1> UKF::update_masked<3>(
+  const Eigen::Matrix<double, 3, 1>&,
+  const std::function<Eigen::Matrix<double, 3, 1>(const StateVector&)>&,
+  const Eigen::Matrix<double, 3, 3>&,
+  const std::array<bool, STATE_DIM>&,
+  unsigned int
+);
+template Eigen::Matrix<double, 6, 1> UKF::update_masked<6>(
+  const Eigen::Matrix<double, 6, 1>&,
+  const std::function<Eigen::Matrix<double, 6, 1>(const StateVector&)>&,
+  const Eigen::Matrix<double, 6, 6>&,
+  const std::array<bool, STATE_DIM>&,
   unsigned int
 );
 

--- a/fusioncore_core/tests/test_gnss.cpp
+++ b/fusioncore_core/tests/test_gnss.cpp
@@ -402,6 +402,74 @@ TEST(GNSSTest, RotationHeadingValidatesFromLeverArmArc)
   EXPECT_LT(status.last_heading_sigma, config.gps_rotation_heading_max_sigma);
 }
 
+TEST(GNSSTest, TrackHeadingDoesNotOverrideRotationHeading)
+{
+  FusionCoreConfig config;
+  config.outlier_rejection = false;
+  config.adaptive_gnss = false;
+  config.heading_observable_distance = 1000.0;
+  config.gps_track_heading_enabled = true;
+  config.gps_track_heading_min_dist = 1.0;
+  config.gps_track_heading_min_speed = 0.1;
+  config.gps_track_heading_max_yaw_rate = 0.05;
+  config.gps_track_heading_max_yaw_delta = M_PI;
+  config.gps_rotation_heading_enabled = true;
+  config.gps_rotation_heading_min_yaw_delta = 0.8;
+  config.gps_rotation_heading_min_arc_baseline = 0.20;
+  config.gps_rotation_heading_max_base_translation = 0.05;
+  config.gps_rotation_heading_max_sigma = 0.4;
+  config.gps_rotation_heading_sigma_floor = 0.02;
+  config.gps_rotation_heading_delta_yaw_sigma = 0.01;
+
+  FusionCore fc(config);
+
+  State initial;
+  initial.P = StateMatrix::Identity() * 0.1;
+  fc.init(initial, 0.0);
+
+  auto make_rotation_fix = [](double yaw) {
+    constexpr double lever_x = 0.32;
+    GnssFix fix;
+    fix.fix_type = GnssFixType::GPS_FIX;
+    fix.satellites = 8;
+    fix.hdop = 1.0;
+    fix.vdop = 1.0;
+    fix.lever_arm.x = lever_x;
+    fix.x = std::cos(yaw) * lever_x;
+    fix.y = std::sin(yaw) * lever_x;
+    fix.z = 0.0;
+    fix.has_full_covariance = true;
+    fix.full_covariance = Eigen::Matrix3d::Zero();
+    fix.full_covariance(0, 0) = 0.05 * 0.05;
+    fix.full_covariance(1, 1) = 0.05 * 0.05;
+    fix.full_covariance(2, 2) = 0.10 * 0.10;
+    return fix;
+  };
+
+  ASSERT_TRUE(fc.update_gnss(0.1, make_rotation_fix(0.0)));
+
+  constexpr double wz = 0.6;
+  double t = 0.1;
+  for (int i = 1; i <= 180; ++i) {
+    t = 0.1 + i * 0.01;
+    fc.update_encoder(t, 0.0, 0.0, wz, 1e-4, 1e-4, 1e-4);
+  }
+
+  const double yaw = fc.get_state().yaw();
+  ASSERT_TRUE(fc.update_gnss(t, make_rotation_fix(yaw)));
+  ASSERT_EQ(fc.get_status().heading_source, HeadingSource::GPS_ROTATION);
+
+  const double sigma_after_rotation = fc.get_status().last_heading_sigma;
+
+  fc.update_encoder(t + 0.5, 0.5, 0.0, 0.0, 1e-4, 1e-4, 1e-4);
+  ASSERT_TRUE(fc.update_gnss(t + 1.0, makePreciseTrackFix(2.0, 0.0)));
+
+  const auto status = fc.get_status();
+  EXPECT_TRUE(status.heading_validated);
+  EXPECT_EQ(status.heading_source, HeadingSource::GPS_ROTATION);
+  EXPECT_DOUBLE_EQ(status.last_heading_sigma, sigma_after_rotation);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/fusioncore_core/tests/test_gnss.cpp
+++ b/fusioncore_core/tests/test_gnss.cpp
@@ -470,6 +470,121 @@ TEST(GNSSTest, TrackHeadingDoesNotOverrideRotationHeading)
   EXPECT_DOUBLE_EQ(status.last_heading_sigma, sigma_after_rotation);
 }
 
+TEST(GNSSTest, RotationHeadingDoesNotRebootstrapAfterValidation)
+{
+  FusionCoreConfig config;
+  config.outlier_rejection = false;
+  config.adaptive_gnss = false;
+  config.gps_track_heading_enabled = false;
+  config.gps_rotation_heading_enabled = true;
+  config.gps_rotation_heading_min_yaw_delta = 0.8;
+  config.gps_rotation_heading_min_arc_baseline = 0.20;
+  config.gps_rotation_heading_max_base_translation = 0.05;
+  config.gps_rotation_heading_max_sigma = 0.4;
+  config.gps_rotation_heading_sigma_floor = 0.02;
+  config.gps_rotation_heading_delta_yaw_sigma = 0.01;
+
+  FusionCore fc(config);
+
+  State initial;
+  initial.P = StateMatrix::Identity() * 0.1;
+  fc.init(initial, 0.0);
+
+  auto make_rotation_fix = [](double yaw) {
+    constexpr double lever_x = 0.32;
+    GnssFix fix;
+    fix.fix_type = GnssFixType::GPS_FIX;
+    fix.satellites = 8;
+    fix.hdop = 1.0;
+    fix.vdop = 1.0;
+    fix.lever_arm.x = lever_x;
+    fix.x = std::cos(yaw) * lever_x;
+    fix.y = std::sin(yaw) * lever_x;
+    fix.z = 0.0;
+    fix.has_full_covariance = true;
+    fix.full_covariance = Eigen::Matrix3d::Zero();
+    fix.full_covariance(0, 0) = 0.05 * 0.05;
+    fix.full_covariance(1, 1) = 0.05 * 0.05;
+    fix.full_covariance(2, 2) = 0.10 * 0.10;
+    return fix;
+  };
+
+  ASSERT_TRUE(fc.update_gnss(0.1, make_rotation_fix(0.0)));
+
+  constexpr double wz = 0.6;
+  double t = 0.1;
+  for (int i = 1; i <= 180; ++i) {
+    t = 0.1 + i * 0.01;
+    fc.update_encoder(t, 0.0, 0.0, wz, 1e-4, 1e-4, 1e-4);
+  }
+
+  ASSERT_TRUE(fc.update_gnss(t, make_rotation_fix(fc.get_state().yaw())));
+  ASSERT_EQ(fc.get_status().heading_source, HeadingSource::GPS_ROTATION);
+  const double sigma_after_rotation = fc.get_status().last_heading_sigma;
+
+  for (int i = 1; i <= 180; ++i) {
+    t += 0.01;
+    fc.update_encoder(t, 0.0, 0.0, wz, 1e-4, 1e-4, 1e-4);
+  }
+
+  const double yaw_before_bad_fix = fc.get_state().yaw();
+  ASSERT_TRUE(fc.update_gnss(t, make_rotation_fix(yaw_before_bad_fix + 1.0)));
+
+  const auto status = fc.get_status();
+  EXPECT_EQ(status.heading_source, HeadingSource::GPS_ROTATION);
+  EXPECT_DOUBLE_EQ(status.last_heading_sigma, sigma_after_rotation);
+  EXPECT_NEAR(fc.get_state().yaw(), yaw_before_bad_fix, 0.02);
+}
+
+TEST(GNSSTest, LeverArmPositionUpdateDoesNotSteerValidatedHeading)
+{
+  FusionCoreConfig config;
+  config.outlier_rejection = false;
+  config.adaptive_gnss = false;
+  config.gps_track_heading_enabled = false;
+  config.gps_rotation_heading_enabled = false;
+
+  FusionCore fc(config);
+
+  State initial;
+  initial.P = StateMatrix::Identity() * 1e-4;
+  initial.P(X, X) = 1.0;
+  initial.P(Y, Y) = 1.0;
+  initial.P(QZ, QZ) = 0.1;
+  initial.P(X, QZ) = 0.2;
+  initial.P(QZ, X) = 0.2;
+  fc.init(initial, 0.0);
+
+  GnssHeading heading;
+  heading.valid = true;
+  heading.heading_rad = 0.0;
+  heading.accuracy_rad = 10.0;
+  ASSERT_TRUE(fc.update_gnss_heading(0.1, heading));
+  ASSERT_TRUE(fc.get_status().heading_validated);
+
+  const double yaw_before = fc.get_state().yaw();
+
+  GnssFix fix;
+  fix.fix_type = GnssFixType::GPS_FIX;
+  fix.satellites = 8;
+  fix.hdop = 1.0;
+  fix.vdop = 1.0;
+  fix.lever_arm.x = 1.0;
+  fix.x = 5.0;
+  fix.y = 1.0;
+  fix.z = 0.0;
+  fix.has_full_covariance = true;
+  fix.full_covariance = Eigen::Matrix3d::Zero();
+  fix.full_covariance(0, 0) = 0.01 * 0.01;
+  fix.full_covariance(1, 1) = 0.01 * 0.01;
+  fix.full_covariance(2, 2) = 0.05 * 0.05;
+  ASSERT_TRUE(fc.update_gnss(0.2, fix));
+
+  const auto status = fc.get_status();
+  EXPECT_EQ(status.heading_source, HeadingSource::DUAL_ANTENNA);
+  EXPECT_NEAR(fc.get_state().yaw(), yaw_before, 0.02);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/fusioncore_core/tests/test_gnss.cpp
+++ b/fusioncore_core/tests/test_gnss.cpp
@@ -1,30 +1,33 @@
-#include <gtest/gtest.h>
-#include "fusioncore/ukf.hpp"
-#include "fusioncore/state.hpp"
-#include "fusioncore/sensors/gnss.hpp"
 #include "fusioncore/fusioncore.hpp"
+#include "fusioncore/sensors/gnss.hpp"
+#include "fusioncore/state.hpp"
+#include "fusioncore/ukf.hpp"
+
+#include <gtest/gtest.h>
 
 using namespace fusioncore;
 using namespace fusioncore::sensors;
 
 // ─── Test 1: Position measurement function maps state ────────────────────────
 
-TEST(GNSSTest, PosMeasurementFunctionMapsState) {
+TEST(GNSSTest, PosMeasurementFunctionMapsState)
+{
   StateVector x = StateVector::Zero();
   x[X] = 10.0;
   x[Y] = 20.0;
-  x[Z] =  5.0;
+  x[Z] = 5.0;
 
   GnssPosMeasurement z = gnss_pos_measurement_function(x);
 
   EXPECT_DOUBLE_EQ(z[0], 10.0);
   EXPECT_DOUBLE_EQ(z[1], 20.0);
-  EXPECT_DOUBLE_EQ(z[2],  5.0);
+  EXPECT_DOUBLE_EQ(z[2], 5.0);
 }
 
 // ─── Test 2: Heading measurement function maps yaw ───────────────────────────
 
-TEST(GNSSTest, HdgMeasurementFunctionMapsYaw) {
+TEST(GNSSTest, HdgMeasurementFunctionMapsYaw)
+{
   StateVector x = StateVector::Zero();
   // yaw = π/2 → quaternion [cos(π/4), 0, 0, sin(π/4)]
   x[QW] = std::cos(M_PI / 4.0);
@@ -38,40 +41,42 @@ TEST(GNSSTest, HdgMeasurementFunctionMapsYaw) {
 
 // ─── Test 3: Quality-aware noise scales with HDOP ────────────────────────────
 
-TEST(GNSSTest, NoiseScalesWithHDOP) {
+TEST(GNSSTest, NoiseScalesWithHDOP)
+{
   GnssParams params;
   params.base_noise_xy = 1.0;
 
   GnssFix good_fix;
-  good_fix.fix_type   = GnssFixType::GPS_FIX;
+  good_fix.fix_type = GnssFixType::GPS_FIX;
   good_fix.satellites = 8;
-  good_fix.hdop       = 1.0;
-  good_fix.vdop       = 1.5;
+  good_fix.hdop = 1.0;
+  good_fix.vdop = 1.5;
 
   GnssFix poor_fix;
-  poor_fix.fix_type   = GnssFixType::GPS_FIX;
+  poor_fix.fix_type = GnssFixType::GPS_FIX;
   poor_fix.satellites = 5;
-  poor_fix.hdop       = 3.5;
-  poor_fix.vdop       = 5.0;
+  poor_fix.hdop = 3.5;
+  poor_fix.vdop = 5.0;
 
   GnssPosNoiseMatrix R_good = gnss_pos_noise_matrix(params, good_fix);
   GnssPosNoiseMatrix R_poor = gnss_pos_noise_matrix(params, poor_fix);
 
   // Poor fix should have larger noise
-  EXPECT_GT(R_poor(0,0), R_good(0,0));
-  EXPECT_GT(R_poor(2,2), R_good(2,2));
+  EXPECT_GT(R_poor(0, 0), R_good(0, 0));
+  EXPECT_GT(R_poor(2, 2), R_good(2, 2));
 }
 
 // ─── Test 4: Fix validity check works ────────────────────────────────────────
 
-TEST(GNSSTest, FixValidityCheck) {
+TEST(GNSSTest, FixValidityCheck)
+{
   GnssParams params;
 
   GnssFix valid_fix;
-  valid_fix.fix_type   = GnssFixType::GPS_FIX;
+  valid_fix.fix_type = GnssFixType::GPS_FIX;
   valid_fix.satellites = 6;
-  valid_fix.hdop       = 1.5;
-  valid_fix.vdop       = 2.0;
+  valid_fix.hdop = 1.5;
+  valid_fix.vdop = 2.0;
   EXPECT_TRUE(valid_fix.is_valid(params));
 
   GnssFix no_fix;
@@ -79,63 +84,65 @@ TEST(GNSSTest, FixValidityCheck) {
   EXPECT_FALSE(no_fix.is_valid(params));
 
   GnssFix poor_hdop;
-  poor_hdop.fix_type   = GnssFixType::GPS_FIX;
+  poor_hdop.fix_type = GnssFixType::GPS_FIX;
   poor_hdop.satellites = 6;
-  poor_hdop.hdop       = 5.0;  // exceeds max_hdop=4.0
-  poor_hdop.vdop       = 2.0;
+  poor_hdop.hdop = 5.0;  // exceeds max_hdop=4.0
+  poor_hdop.vdop = 2.0;
   EXPECT_FALSE(poor_hdop.is_valid(params));
 
   GnssFix few_sats;
-  few_sats.fix_type   = GnssFixType::GPS_FIX;
-  few_sats.satellites = 3;     // below min_satellites=4
-  few_sats.hdop       = 1.5;
-  few_sats.vdop       = 2.0;
+  few_sats.fix_type = GnssFixType::GPS_FIX;
+  few_sats.satellites = 3;  // below min_satellites=4
+  few_sats.hdop = 1.5;
+  few_sats.vdop = 2.0;
   EXPECT_FALSE(few_sats.is_valid(params));
 }
 
 // ─── Test 4b: min_fix_type gating ───────────────────────────────────────────
 
-TEST(GNSSTest, MinFixTypeGating) {
+TEST(GNSSTest, MinFixTypeGating)
+{
   GnssParams params;
   params.min_fix_type = GnssFixType::RTK_FLOAT;
 
   GnssFix gps_fix;
-  gps_fix.fix_type   = GnssFixType::GPS_FIX;
+  gps_fix.fix_type = GnssFixType::GPS_FIX;
   gps_fix.satellites = 8;
-  gps_fix.hdop       = 1.0;
-  gps_fix.vdop       = 1.5;
+  gps_fix.hdop = 1.0;
+  gps_fix.vdop = 1.5;
   EXPECT_FALSE(gps_fix.is_valid(params));  // GPS_FIX < RTK_FLOAT
 
   GnssFix dgps_fix;
-  dgps_fix.fix_type   = GnssFixType::DGPS_FIX;
+  dgps_fix.fix_type = GnssFixType::DGPS_FIX;
   dgps_fix.satellites = 8;
-  dgps_fix.hdop       = 1.0;
-  dgps_fix.vdop       = 1.5;
+  dgps_fix.hdop = 1.0;
+  dgps_fix.vdop = 1.5;
   EXPECT_FALSE(dgps_fix.is_valid(params));  // DGPS < RTK_FLOAT
 
   GnssFix rtk_float;
-  rtk_float.fix_type   = GnssFixType::RTK_FLOAT;
+  rtk_float.fix_type = GnssFixType::RTK_FLOAT;
   rtk_float.satellites = 8;
-  rtk_float.hdop       = 1.0;
-  rtk_float.vdop       = 1.5;
+  rtk_float.hdop = 1.0;
+  rtk_float.vdop = 1.5;
   EXPECT_TRUE(rtk_float.is_valid(params));  // RTK_FLOAT == min
 
   GnssFix rtk_fixed;
-  rtk_fixed.fix_type   = GnssFixType::RTK_FIXED;
+  rtk_fixed.fix_type = GnssFixType::RTK_FIXED;
   rtk_fixed.satellites = 8;
-  rtk_fixed.hdop       = 1.0;
-  rtk_fixed.vdop       = 1.5;
+  rtk_fixed.hdop = 1.0;
+  rtk_fixed.vdop = 1.5;
   EXPECT_TRUE(rtk_fixed.is_valid(params));  // RTK_FIXED > min
 }
 
 // ─── Test 5: ECEF to ENU conversion ─────────────────────────────────────────
 
-TEST(GNSSTest, ECEFtoENUAtOriginIsZero) {
+TEST(GNSSTest, ECEFtoENUAtOriginIsZero)
+{
   // Reference point: somewhere in Hamilton Ontario
   LLAPoint ref_lla;
   ref_lla.lat_rad = 43.25 * M_PI / 180.0;
   ref_lla.lon_rad = -79.87 * M_PI / 180.0;
-  ref_lla.alt_m   = 100.0;
+  ref_lla.alt_m = 100.0;
 
   ECEFPoint ref;
   ref.x = 918151.0;
@@ -152,27 +159,30 @@ TEST(GNSSTest, ECEFtoENUAtOriginIsZero) {
 
 // ─── Test 6: GNSS position update corrects drifted position ──────────────────
 
-TEST(GNSSTest, GNSSUpdateCorrectedDriftedPosition) {
+TEST(GNSSTest, GNSSUpdateCorrectedDriftedPosition)
+{
   UKF ukf;
 
   State initial;
-  initial.x     = StateVector::Zero();
-  initial.x[X]  = 50.0;   // drifted far from truth
-  initial.x[Y]  = 30.0;
-  initial.P     = StateMatrix::Identity() * 10.0;
+  initial.x = StateVector::Zero();
+  initial.x[X] = 50.0;  // drifted far from truth
+  initial.x[Y] = 30.0;
+  initial.P = StateMatrix::Identity() * 10.0;
 
   ukf.init(initial);
 
   // GNSS says: actually at (1, 1, 0)
   GnssPosMeasurement z;
-  z[0] = 1.0; z[1] = 1.0; z[2] = 0.0;
+  z[0] = 1.0;
+  z[1] = 1.0;
+  z[2] = 0.0;
 
   GnssParams params;
   GnssFix fix;
-  fix.fix_type   = GnssFixType::GPS_FIX;
+  fix.fix_type = GnssFixType::GPS_FIX;
   fix.satellites = 8;
-  fix.hdop       = 1.0;
-  fix.vdop       = 1.5;
+  fix.hdop = 1.0;
+  fix.vdop = 1.5;
 
   GnssPosNoiseMatrix R = gnss_pos_noise_matrix(params, fix);
 
@@ -188,15 +198,16 @@ TEST(GNSSTest, GNSSUpdateCorrectedDriftedPosition) {
 // Outdoor wheeled robot, GNSS + IMU + encoders
 // This is the exact use case Stefan posted on ROS Discourse Dec 2024
 
-TEST(GNSSTest, StefanConfigurationFullFusion) {
+TEST(GNSSTest, StefanConfigurationFullFusion)
+{
   FusionCoreConfig config;
-  config.ukf.q_position    = 1e-4;
-  config.ukf.q_velocity    = 1e-4;
+  config.ukf.q_position = 1e-4;
+  config.ukf.q_velocity = 1e-4;
   config.ukf.q_orientation = 1e-4;
   config.ukf.q_angular_vel = 1e-4;
-  config.ukf.q_acceleration= 1e-4;
-  config.ukf.q_gyro_bias   = 1e-6;
-  config.ukf.q_accel_bias  = 1e-6;
+  config.ukf.q_acceleration = 1e-4;
+  config.ukf.q_gyro_bias = 1e-6;
+  config.ukf.q_accel_bias = 1e-6;
 
   FusionCore fc(config);
 
@@ -207,10 +218,10 @@ TEST(GNSSTest, StefanConfigurationFullFusion) {
 
   GnssParams gnss_params;
   GnssFix fix;
-  fix.fix_type   = GnssFixType::GPS_FIX;
+  fix.fix_type = GnssFixType::GPS_FIX;
   fix.satellites = 8;
-  fix.hdop       = 1.2;
-  fix.vdop       = 1.8;
+  fix.hdop = 1.2;
+  fix.vdop = 1.8;
 
   // Simulate 5 seconds: robot drives forward 5 meters
   // IMU @ 100Hz, encoder @ 50Hz, GNSS @ 1Hz
@@ -218,7 +229,7 @@ TEST(GNSSTest, StefanConfigurationFullFusion) {
     double t = i * 0.01;
 
     // IMU
-    fc.update_imu(t, 0,0,0, 0,0,0);
+    fc.update_imu(t, 0, 0, 0, 0, 0, 0);
 
     // Encoder @ 50Hz
     if (i % 2 == 0) {
@@ -246,12 +257,94 @@ TEST(GNSSTest, StefanConfigurationFullFusion) {
   // This test proves stability of the full pipeline
   auto status = fc.get_status();
   EXPECT_TRUE(status.initialized);
-  EXPECT_EQ(status.imu_health,     SensorHealth::OK);
+  EXPECT_EQ(status.imu_health, SensorHealth::OK);
   EXPECT_EQ(status.encoder_health, SensorHealth::OK);
-  EXPECT_GT(status.update_count,   0);
+  EXPECT_GT(status.update_count, 0);
 }
 
-TEST(GNSSTest, RotationHeadingValidatesFromLeverArmArc) {
+static GnssFix makePreciseTrackFix(double x, double y)
+{
+  GnssFix fix;
+  fix.fix_type = GnssFixType::GPS_FIX;
+  fix.satellites = 8;
+  fix.hdop = 1.0;
+  fix.vdop = 1.0;
+  fix.x = x;
+  fix.y = y;
+  fix.z = 0.0;
+  fix.has_full_covariance = true;
+  fix.full_covariance = Eigen::Matrix3d::Zero();
+  fix.full_covariance(0, 0) = 0.02 * 0.02;
+  fix.full_covariance(1, 1) = 0.02 * 0.02;
+  fix.full_covariance(2, 2) = 0.05 * 0.05;
+  return fix;
+}
+
+TEST(GNSSTest, TrackHeadingValidatesDuringStraightForwardMotion)
+{
+  FusionCoreConfig config;
+  config.outlier_rejection = false;
+  config.adaptive_gnss = false;
+  config.gps_track_heading_enabled = true;
+  config.gps_rotation_heading_enabled = false;
+  config.heading_observable_distance = 1000.0;
+  config.gps_track_heading_min_dist = 1.0;
+  config.gps_track_heading_min_speed = 0.1;
+  config.gps_track_heading_max_yaw_rate = 0.05;
+  config.gps_track_heading_max_yaw_delta = 0.1;
+
+  FusionCore fc(config);
+  State initial;
+  initial.P = StateMatrix::Identity() * 0.1;
+  fc.init(initial, 0.0);
+
+  ASSERT_TRUE(fc.update_gnss(0.1, makePreciseTrackFix(0.0, 0.0)));
+  fc.update_encoder(0.2, 0.5, 0.0, 0.0, 1e-4, 1e-4, 1e-4);
+  ASSERT_TRUE(fc.update_gnss(1.0, makePreciseTrackFix(2.0, 0.0)));
+
+  const auto status = fc.get_status();
+  EXPECT_TRUE(status.heading_validated);
+  EXPECT_EQ(status.heading_source, HeadingSource::GPS_TRACK);
+  EXPECT_GT(status.last_heading_sigma, 0.0);
+}
+
+TEST(GNSSTest, TrackHeadingSkipsCurvedTrackWindow)
+{
+  FusionCoreConfig config;
+  config.outlier_rejection = false;
+  config.adaptive_gnss = false;
+  config.gps_track_heading_enabled = true;
+  config.gps_rotation_heading_enabled = false;
+  config.heading_observable_distance = 1000.0;
+  config.gps_track_heading_min_dist = 1.0;
+  config.gps_track_heading_min_speed = 0.1;
+  config.gps_track_heading_max_yaw_rate = 10.0;
+  config.gps_track_heading_max_yaw_delta = 0.1;
+
+  FusionCore fc(config);
+  State initial;
+  initial.P = StateMatrix::Identity() * 0.1;
+  fc.init(initial, 0.0);
+
+  ASSERT_TRUE(fc.update_gnss(0.1, makePreciseTrackFix(0.0, 0.0)));
+
+  double t = 0.1;
+  for (int i = 1; i <= 20; ++i) {
+    t = 0.1 + i * 0.1;
+    fc.update_encoder(t, 0.5, 0.0, 0.2, 1e-4, 1e-4, 1e-4);
+  }
+  ASSERT_GT(std::abs(fc.get_state().yaw()), config.gps_track_heading_max_yaw_delta);
+
+  ASSERT_TRUE(fc.update_gnss(t + 0.1, makePreciseTrackFix(2.0, 0.0)));
+
+  const auto status = fc.get_status();
+  EXPECT_FALSE(status.heading_validated);
+  EXPECT_EQ(status.heading_source, HeadingSource::NONE);
+  EXPECT_DOUBLE_EQ(status.last_heading_sigma, 0.0);
+}
+
+TEST(GNSSTest, RotationHeadingValidatesFromLeverArmArc)
+{
   FusionCoreConfig config;
   config.outlier_rejection = false;
   config.adaptive_gnss = false;
@@ -283,9 +376,9 @@ TEST(GNSSTest, RotationHeadingValidatesFromLeverArmArc) {
     fix.z = 0.0;
     fix.has_full_covariance = true;
     fix.full_covariance = Eigen::Matrix3d::Zero();
-    fix.full_covariance(0,0) = 0.05 * 0.05;
-    fix.full_covariance(1,1) = 0.05 * 0.05;
-    fix.full_covariance(2,2) = 0.10 * 0.10;
+    fix.full_covariance(0, 0) = 0.05 * 0.05;
+    fix.full_covariance(1, 1) = 0.05 * 0.05;
+    fix.full_covariance(2, 2) = 0.10 * 0.10;
     return fix;
   };
 
@@ -309,7 +402,8 @@ TEST(GNSSTest, RotationHeadingValidatesFromLeverArmArc) {
   EXPECT_LT(status.last_heading_sigma, config.gps_rotation_heading_max_sigma);
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char ** argv)
+{
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/fusioncore_core/tests/test_gnss.cpp
+++ b/fusioncore_core/tests/test_gnss.cpp
@@ -251,6 +251,64 @@ TEST(GNSSTest, StefanConfigurationFullFusion) {
   EXPECT_GT(status.update_count,   0);
 }
 
+TEST(GNSSTest, RotationHeadingValidatesFromLeverArmArc) {
+  FusionCoreConfig config;
+  config.outlier_rejection = false;
+  config.adaptive_gnss = false;
+  config.gps_track_heading_enabled = false;
+  config.gps_rotation_heading_enabled = true;
+  config.gps_rotation_heading_min_yaw_delta = 0.8;
+  config.gps_rotation_heading_min_arc_baseline = 0.20;
+  config.gps_rotation_heading_max_base_translation = 0.05;
+  config.gps_rotation_heading_max_sigma = 0.4;
+  config.gps_rotation_heading_sigma_floor = 0.02;
+  config.gps_rotation_heading_delta_yaw_sigma = 0.01;
+
+  FusionCore fc(config);
+
+  State initial;
+  initial.P = StateMatrix::Identity() * 0.1;
+  fc.init(initial, 0.0);
+
+  auto make_fix = [](double yaw) {
+    constexpr double lever_x = 0.32;
+    GnssFix fix;
+    fix.fix_type = GnssFixType::GPS_FIX;
+    fix.satellites = 8;
+    fix.hdop = 1.0;
+    fix.vdop = 1.0;
+    fix.lever_arm.x = lever_x;
+    fix.x = std::cos(yaw) * lever_x;
+    fix.y = std::sin(yaw) * lever_x;
+    fix.z = 0.0;
+    fix.has_full_covariance = true;
+    fix.full_covariance = Eigen::Matrix3d::Zero();
+    fix.full_covariance(0,0) = 0.05 * 0.05;
+    fix.full_covariance(1,1) = 0.05 * 0.05;
+    fix.full_covariance(2,2) = 0.10 * 0.10;
+    return fix;
+  };
+
+  ASSERT_TRUE(fc.update_gnss(0.1, make_fix(0.0)));
+
+  constexpr double wz = 0.6;
+  double t = 0.1;
+  for (int i = 1; i <= 180; ++i) {
+    t = 0.1 + i * 0.01;
+    fc.update_encoder(t, 0.0, 0.0, wz, 1e-4, 1e-4, 1e-4);
+  }
+
+  const double yaw = fc.get_state().yaw();
+  ASSERT_GT(std::abs(yaw), config.gps_rotation_heading_min_yaw_delta);
+  ASSERT_TRUE(fc.update_gnss(t, make_fix(yaw)));
+
+  const auto status = fc.get_status();
+  EXPECT_TRUE(status.heading_validated);
+  EXPECT_EQ(status.heading_source, HeadingSource::GPS_ROTATION);
+  EXPECT_GT(status.last_heading_sigma, 0.0);
+  EXPECT_LT(status.last_heading_sigma, config.gps_rotation_heading_max_sigma);
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/fusioncore_ros/src/fusion_node.cpp
+++ b/fusioncore_ros/src/fusion_node.cpp
@@ -11,7 +11,7 @@
 #include <gps_msgs/msg/gps_fix.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2/LinearMath/Quaternion.h>
@@ -214,7 +214,17 @@ public:
     declare_parameter("gnss.track_heading_max_sigma", 0.4);
     declare_parameter("gnss.track_heading_min_speed",    0.2);
     declare_parameter("gnss.track_heading_max_yaw_rate", 0.3);
+    declare_parameter("gnss.track_heading_max_yaw_delta", 0.15);
     declare_parameter("gnss.lever_arm_max_heading_sigma_deg", 20.0);
+    declare_parameter("gnss.heading_observable_distance", 5.0);
+    declare_parameter("gnss.rotation_heading_enabled", true);
+    declare_parameter("gnss.rotation_heading_min_yaw_delta", 1.0);
+    declare_parameter("gnss.rotation_heading_min_arc_baseline", 0.25);
+    declare_parameter("gnss.rotation_heading_max_base_translation", 0.20);
+    declare_parameter("gnss.rotation_heading_max_sigma", 0.4);
+    declare_parameter("gnss.rotation_heading_sigma_floor", 0.05);
+    declare_parameter("gnss.rotation_heading_delta_yaw_sigma", 0.03);
+    declare_parameter("gnss.rotation_heading_max_window_s", 10.0);
 
     declare_parameter("adaptive.imu",               true);
     declare_parameter("adaptive.encoder",           true);
@@ -420,8 +430,26 @@ public:
     config.gps_track_heading_max_sigma     = get_parameter("gnss.track_heading_max_sigma").as_double();
     config.gps_track_heading_min_speed     = get_parameter("gnss.track_heading_min_speed").as_double();
     config.gps_track_heading_max_yaw_rate  = get_parameter("gnss.track_heading_max_yaw_rate").as_double();
+    config.gps_track_heading_max_yaw_delta = get_parameter("gnss.track_heading_max_yaw_delta").as_double();
     config.gnss_lever_arm_max_heading_sigma_deg =
       get_parameter("gnss.lever_arm_max_heading_sigma_deg").as_double();
+    config.heading_observable_distance =
+      get_parameter("gnss.heading_observable_distance").as_double();
+    config.gps_rotation_heading_enabled = get_parameter("gnss.rotation_heading_enabled").as_bool();
+    config.gps_rotation_heading_min_yaw_delta =
+      get_parameter("gnss.rotation_heading_min_yaw_delta").as_double();
+    config.gps_rotation_heading_min_arc_baseline =
+      get_parameter("gnss.rotation_heading_min_arc_baseline").as_double();
+    config.gps_rotation_heading_max_base_translation =
+      get_parameter("gnss.rotation_heading_max_base_translation").as_double();
+    config.gps_rotation_heading_max_sigma =
+      get_parameter("gnss.rotation_heading_max_sigma").as_double();
+    config.gps_rotation_heading_sigma_floor =
+      get_parameter("gnss.rotation_heading_sigma_floor").as_double();
+    config.gps_rotation_heading_delta_yaw_sigma =
+      get_parameter("gnss.rotation_heading_delta_yaw_sigma").as_double();
+    config.gps_rotation_heading_max_window_s =
+      get_parameter("gnss.rotation_heading_max_window_s").as_double();
 
     config.adaptive_imu               = get_parameter("adaptive.imu").as_bool();
     config.adaptive_encoder           = get_parameter("adaptive.encoder").as_bool();
@@ -1822,14 +1850,14 @@ private:
     fix.source_id = source_id;
     fix.lever_arm = (source_id == 0) ? gnss_lever_arm_ : gnss_lever_arm2_;
 
-    // gps_msgs/GPSStatus constants:
-    //   STATUS_NO_FIX=-1, STATUS_FIX=0, STATUS_SBAS_FIX=1, STATUS_GBAS_FIX=2
-    //   STATUS_DGPS_FIX=18, STATUS_RTK_FIX=19, STATUS_RTK_FLOAT=20
+    // RTK constants are not available in all gps_msgs releases.
+    constexpr int16_t kStatusRtkFix = 19;
+    constexpr int16_t kStatusRtkFloat = 20;
     using S = gps_msgs::msg::GPSStatus;
     switch (msg->status.status) {
-      case S::STATUS_RTK_FIX:
+      case kStatusRtkFix:
         fix.fix_type = fusioncore::sensors::GnssFixType::RTK_FIXED; break;
-      case S::STATUS_RTK_FLOAT:
+      case kStatusRtkFloat:
         fix.fix_type = fusioncore::sensors::GnssFixType::RTK_FLOAT; break;
       case S::STATUS_GBAS_FIX:
         fix.fix_type = fusioncore::sensors::GnssFixType::RTK_FIXED; break;
@@ -2386,6 +2414,7 @@ private:
         case fusioncore::HeadingSource::DUAL_ANTENNA:    return "DUAL_ANTENNA";
         case fusioncore::HeadingSource::IMU_ORIENTATION: return "IMU_ORIENTATION (9-axis)";
         case fusioncore::HeadingSource::GPS_TRACK:       return "GPS_TRACK";
+        case fusioncore::HeadingSource::GPS_ROTATION:    return "GPS_ROTATION";
       }
       return "Unknown";
     };
@@ -2401,6 +2430,7 @@ private:
       filter_level, filter_msg,
       {{"heading_source",        heading_src_str(status.heading_source)},
        {"heading_validated",     status.heading_validated ? "true" : "false"},
+       {"last_heading_sigma_rad", std::to_string(status.last_heading_sigma)},
        {"distance_traveled_m",   std::to_string(status.distance_traveled)},
        {"position_uncertainty_m", std::to_string(std::sqrt(status.position_uncertainty))},
        {"update_count",          std::to_string(status.update_count)}}));


### PR DESCRIPTION
## Summary

This adds a GNSS rotation-based heading bootstrap for setups where the GPS/GNSS antenna is not mounted at `base_link`.

In my OpenMower setup the antenna has a lever arm relative to `base_link`, so robot rotation makes the antenna trace a small arc. The observed GNSS displacement, relative yaw from odometry/gyro, and configured lever arm can infer absolute heading before normal track-based heading is reliable.

Additional change:

```
  // Minimum forward speed to count as real motion
  // Below this threshold: could be GPS jitter, spinning in place, or sliding
  const double MIN_SPEED = 0.2;  // m/s

  // Maximum yaw rate: if spinning fast, heading is not observable from track
  const double MAX_YAW_RATE = 0.3;  // rad/s (~17 deg/s)
```

Is extracted into parameter. In my case, with RTK, GPS jitter is much less, so min speed threshold can be lowered down. Happy to extract it into a separate PR. 

The PR also  includes small ROS compatibility fixes needed in Jazzy. (should not be a part of this PR)

## Status

This is WIP.

I have only done a quick/superficial validation in simulation so far. I have not yet tested this on real hardware in an outdoor environment. I plan to do that in the coming days.
