### PR TITLE
Build on ROS 2 Lyrical: ament_cmake_auto migration + .hpp tf2 headers

### DIFF
--- a/fusioncore_ros/CMakeLists.txt
+++ b/fusioncore_ros/CMakeLists.txt
@@ -4,24 +4,11 @@ project(fusioncore_ros VERSION 0.3.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(nav_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(geographic_msgs REQUIRED)
-find_package(gps_msgs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_ros REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
-find_package(compass_msgs REQUIRED)
-find_package(eigen3_cmake_module REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+# Non-ROS deps not picked up by ament_auto_find_build_dependencies()
 find_package(Eigen3 REQUIRED)
-find_package(fusioncore_core REQUIRED)
-find_package(diagnostic_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
 find_package(PROJ QUIET)
 if(NOT PROJ_FOUND)
   # PROJ 8 (Ubuntu 22.04 / Humble) ships no CMake config; fall back to pkg-config
@@ -33,7 +20,6 @@ if(NOT PROJ_FOUND)
     target_link_libraries(PROJ::proj INTERFACE ${PROJ_LINK_LIBRARIES})
   endif()
 endif()
-find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/FromLL.srv"
@@ -42,57 +28,15 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES geographic_msgs geometry_msgs std_msgs
 )
 
-add_executable(fusioncore_node
+ament_auto_add_executable(fusioncore_node
   src/fusion_node.cpp
 )
 
-target_include_directories(fusioncore_node PRIVATE
-  ${fusioncore_core_INCLUDE_DIRS}
-)
-
-target_link_directories(fusioncore_node PRIVATE
-  ${fusioncore_core_LIB_DEPENDS}
-)
-
-ament_target_dependencies(fusioncore_node
-  rclcpp
-  rclcpp_lifecycle
-  sensor_msgs
-  nav_msgs
-  geometry_msgs
-  geographic_msgs
-  gps_msgs
-  tf2
-  tf2_ros
-  tf2_geometry_msgs
-  fusioncore_core
-  compass_msgs
-  diagnostic_msgs
-  std_msgs
-  std_srvs
-)
-
 rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
-target_link_libraries(fusioncore_node ${cpp_typesupport_target})
-
 target_link_libraries(fusioncore_node
+  ${cpp_typesupport_target}
   Eigen3::Eigen
   PROJ::proj
-)
-
-# Explicitly link the static library
-find_library(FUSIONCORE_CORE_LIB
-  NAMES fusioncore_core
-  HINTS ${fusioncore_core_DIR}/../../../lib
-)
-if(FUSIONCORE_CORE_LIB)
-  target_link_libraries(fusioncore_node ${FUSIONCORE_CORE_LIB})
-else()
-  message(FATAL_ERROR "Could not find libfusioncore_core.a")
-endif()
-
-install(TARGETS fusioncore_node
-  DESTINATION lib/${PROJECT_NAME}
 )
 
 install(DIRECTORY config launch
@@ -106,4 +50,4 @@ if(BUILD_TESTING)
   target_link_libraries(test_proj_axis_order PROJ::proj)
 endif()
 
-ament_package()
+ament_auto_package()

--- a/fusioncore_ros/package.xml
+++ b/fusioncore_ros/package.xml
@@ -11,12 +11,13 @@
   <url type="bugtracker">https://github.com/manankharwar/fusioncore/issues</url>
   <url type="documentation">https://manankharwar.github.io/fusioncore</url>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>rosidl_default_runtime</depend>
   <depend>geographic_msgs</depend>
   <depend>gps_msgs</depend>
+  <depend>std_msgs</depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <depend>rclcpp</depend>

--- a/fusioncore_ros/src/fusion_node.cpp
+++ b/fusioncore_ros/src/fusion_node.cpp
@@ -16,10 +16,16 @@
 #include <tf2_ros/transform_broadcaster.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
+#if __has_include(<tf2/LinearMath/Quaternion.hpp>)
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#else
 #include <tf2/LinearMath/Quaternion.h>
-#include <compass_msgs/msg/azimuth.hpp>
 #include <tf2/LinearMath/Vector3.h>
 #include <tf2/LinearMath/Matrix3x3.h>
+#endif
+#include <compass_msgs/msg/azimuth.hpp>
 #include <rclcpp/executors/multi_threaded_executor.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>


### PR DESCRIPTION
Makes `fusioncore_ros` build on ROS 2 Lyrical (unchanged on Jazzy/Humble).

- **CMakeLists.txt** — migrate to `ament_cmake_auto`. ROS 2 Lyrical removed `ament_target_dependencies()`, so `fusioncore_node` uses `ament_auto_add_executable` with deps resolved from `package.xml` via `ament_auto_find_build_dependencies()`. `Eigen3` and `PROJ` stay explicit. Also drops the now-redundant `fusioncore_core` `find_library` workaround and the manual include/link directories (the imported target comes through `ament_export_targets(... HAS_LIBRARY_TARGET)`).
- **package.xml** — `buildtool_depend` `ament_cmake` → `ament_cmake_auto`; add `std_msgs` depend (required by `GnssStatus.msg`/`FilterHealth.msg` now that deps come from the manifest).
- **fusion_node.cpp** — guard the `tf2/LinearMath/*` includes with `__has_include` so they resolve to the `.hpp` headers Lyrical renamed them to, while still building on Jazzy.

### Testing
Clean `colcon build` of `fusioncore_ros` on ROS 2 Lyrical.
