### PR TITLE
fix(gnss): warn when covariance bypasses DOP gates

### DIFF
--- a/fusioncore_ros/CMakeLists.txt
+++ b/fusioncore_ros/CMakeLists.txt
@@ -64,6 +64,9 @@ if(BUILD_TESTING)
   ament_add_gtest(test_stale_rate tests/test_stale_rate.cpp)
   target_include_directories(test_stale_rate PRIVATE include)
 
+  ament_add_gtest(test_gnss_dop_gate_warning tests/test_gnss_dop_gate_warning.cpp)
+  target_include_directories(test_gnss_dop_gate_warning PRIVATE include)
+
   # Launches the real node and asserts /fromLL is advertised with the type
   # nav2_waypoint_follower binds. A different-but-identical type is invisible to
   # Nav2 and only a real typed client catches it, which is how issue #73 shipped

--- a/fusioncore_ros/include/fusioncore_ros/gnss_dop_gate_warning.hpp
+++ b/fusioncore_ros/include/fusioncore_ros/gnss_dop_gate_warning.hpp
@@ -1,0 +1,34 @@
+// Tracks the one-time warning that DOP thresholds are bypassed by covariance.
+//
+// Kept separate from the ROS node so the state transition can be unit tested
+// without standing up a lifecycle node.
+
+#ifndef FUSIONCORE_ROS__GNSS_DOP_GATE_WARNING_HPP_
+#define FUSIONCORE_ROS__GNSS_DOP_GATE_WARNING_HPP_
+
+namespace fusioncore_ros
+{
+
+class GnssDopGateWarning
+{
+public:
+  bool should_warn(bool covariance_gate_active, double max_hdop, double max_vdop)
+  {
+    if (warned_ || !covariance_gate_active ||
+        (max_hdop == kDefaultMaxHdop && max_vdop == kDefaultMaxVdop)) {
+      return false;
+    }
+
+    warned_ = true;
+    return true;
+  }
+
+private:
+  static constexpr double kDefaultMaxHdop = 4.0;
+  static constexpr double kDefaultMaxVdop = 6.0;
+  bool warned_ = false;
+};
+
+}  // namespace fusioncore_ros
+
+#endif  // FUSIONCORE_ROS__GNSS_DOP_GATE_WARNING_HPP_

--- a/fusioncore_ros/src/fusion_node.cpp
+++ b/fusioncore_ros/src/fusion_node.cpp
@@ -39,6 +39,8 @@
 #include <sstream>
 #include <proj.h>
 
+#include "fusioncore_ros/gnss_dop_gate_warning.hpp"
+
 using namespace std::chrono_literals;
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
@@ -471,6 +473,8 @@ public:
     config.gnss.heading_noise  = get_parameter("gnss.heading_noise").as_double();
     config.gnss.max_hdop       = get_parameter("gnss.max_hdop").as_double();
     config.gnss.max_vdop       = get_parameter("gnss.max_vdop").as_double();
+    max_hdop_                  = config.gnss.max_hdop;
+    max_vdop_                  = config.gnss.max_vdop;
     config.gnss.max_sigma_xy   = get_parameter("gnss.max_sigma_xy").as_double();
     config.gnss.max_sigma_z    = get_parameter("gnss.max_sigma_z").as_double();
     max_sigma_xy_              = config.gnss.max_sigma_xy;
@@ -1929,6 +1933,20 @@ private:
 
   // ─── GNSS position callback ────────────────────────────────────────────────
 
+  void warn_if_dop_gate_bypassed(bool covariance_gate_active)
+  {
+    if (!dop_gate_warning_.should_warn(covariance_gate_active, max_hdop_, max_vdop_)) {
+      return;
+    }
+
+    RCLCPP_WARN(get_logger(),
+      "This receiver reports position covariance, so the sigma gate runs "
+      "(gnss.max_sigma_xy=%.1f m, gnss.max_sigma_z=%.1f m). "
+      "gnss.max_hdop=%.1f and gnss.max_vdop=%.1f will not be consulted on this run; "
+      "the DOP path is only used for fixes without covariance.",
+      max_sigma_xy_, max_sigma_z_, max_hdop_, max_vdop_);
+  }
+
   void gnss_callback(const sensor_msgs::msg::NavSatFix::SharedPtr msg, int source_id = 0)
   {
     if (source_id == 0) mark_sensor_received("GNSS");
@@ -2100,6 +2118,8 @@ private:
       fix.vdop = 2.0;
       fix.satellites = 4;  // Fix 10
     }
+
+    warn_if_dop_gate_bypassed(msg->position_covariance_type >= 1 && fix.has_sigma());
 
     bool accepted = fc_->update_gnss(t, fix);
     const auto& dbg = fc_->get_gnss_debug();
@@ -2298,6 +2318,10 @@ private:
       fix.hdop = 1.5;
       fix.vdop = 2.0;
     }
+
+    warn_if_dop_gate_bypassed(
+      msg->position_covariance_type >= gps_msgs::msg::GPSFix::COVARIANCE_TYPE_APPROXIMATED &&
+      fix.has_sigma());
 
     bool accepted = fc_->update_gnss(t, fix);
     const auto& dbg = fc_->get_gnss_debug();
@@ -3085,8 +3109,11 @@ private:
   double      enc2_yaw_noise_ = 0.02;
   // Cached so the GNSS rejection warning can name the limit it failed against.
   // Defaults mirror the declare_parameter values.
+  double      max_hdop_     = 4.0;
+  double      max_vdop_     = 6.0;
   double      max_sigma_xy_ = 25.0;
   double      max_sigma_z_  = 50.0;
+  fusioncore_ros::GnssDopGateWarning dop_gate_warning_;
   std::string vslam_topic_;
   std::string vslam_frame_override_;
   // VSLAM map-to-odom frame offset: applied to every VSLAM measurement.

--- a/fusioncore_ros/tests/test_gnss_dop_gate_warning.cpp
+++ b/fusioncore_ros/tests/test_gnss_dop_gate_warning.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+
+#include "fusioncore_ros/gnss_dop_gate_warning.hpp"
+
+TEST(GnssDopGateWarning, IgnoresDefaultDopThresholds)
+{
+  fusioncore_ros::GnssDopGateWarning warning;
+
+  EXPECT_FALSE(warning.should_warn(true, 4.0, 6.0));
+}
+
+TEST(GnssDopGateWarning, WarnsOnceForTunedHdopWithCovariance)
+{
+  fusioncore_ros::GnssDopGateWarning warning;
+
+  EXPECT_TRUE(warning.should_warn(true, 2.0, 6.0));
+  EXPECT_FALSE(warning.should_warn(true, 2.0, 6.0));
+}
+
+TEST(GnssDopGateWarning, WarnsForTunedVdopWithCovariance)
+{
+  fusioncore_ros::GnssDopGateWarning warning;
+
+  EXPECT_TRUE(warning.should_warn(true, 4.0, 3.0));
+}
+
+TEST(GnssDopGateWarning, WaitsUntilCovarianceActivatesTheSigmaGate)
+{
+  fusioncore_ros::GnssDopGateWarning warning;
+
+  EXPECT_FALSE(warning.should_warn(false, 2.0, 6.0));
+  EXPECT_TRUE(warning.should_warn(true, 2.0, 6.0));
+}


### PR DESCRIPTION
## Summary

- warn once when a valid GNSS covariance selects the sigma gate while `gnss.max_hdop` or `gnss.max_vdop` has been customized
- show the active sigma limits and explain that the DOP path only handles fixes without covariance
- cover both `NavSatFix` and `GPSFix`, with focused tests for defaults, covariance-free fixes, customized HDOP/VDOP, and one-time reporting

## Validation

- `test_gnss_dop_gate_warning`: 4 tests passed (GoogleTest v1.15.2, C++17 with `-Wall -Wextra -Werror`)
- `git diff --check upstream/main...HEAD`

The full ROS 2 `colcon` build and suite were not available locally because this host has no ROS installation and its Docker daemon is inaccessible; the repository CI will run the Jazzy and Humble builds.

Fixes #79
