### PR TITLE
fix: add two independent rejection gates for magnetometer

### DIFF
--- a/fusioncore_core/include/fusioncore/fusioncore.hpp
+++ b/fusioncore_core/include/fusioncore/fusioncore.hpp
@@ -291,6 +291,14 @@ enum class GnssRejectionReason {
   SIGMA_Z_HIGH    = 10, // reported vertical sigma in METRES > max_sigma_z
 };
 
+// Why a magnetometer reading was rejected (or ACCEPTED if it passed).
+enum class MagRejectionReason {
+  NOT_PROCESSED    = 0,
+  ACCEPTED         = 1,
+  CHI2_FAILED      = 2,  // Mahalanobis distance > threshold
+  FIELD_MAGNITUDE  = 3,  // corrected field magnitude outside configured range
+};
+
 // Per-fix observability data: populated by update_gnss() on every call.
 // Retrieve via get_gnss_debug() after update_gnss() returns.
 struct GnssFixDebug {
@@ -314,6 +322,15 @@ struct GnssFixDebug {
   // Lever arm observability
   bool               lever_arm_used     = false;  // was lever arm correction applied for this fix
   double             heading_sigma_deg  = 0.0;    // heading 1-sigma at time of this fix (degrees)
+};
+
+// Per-reading observability data: populated by update_magnetometer() on every call.
+struct MagnetometerDebug {
+  bool              accepted       = false;
+  MagRejectionReason reason        = MagRejectionReason::NOT_PROCESSED;
+  double            mahalanobis_sq = -1.0;
+  double            chi2_threshold  = 0.0;
+  double            measured_field  = 0.0;
 };
 
 enum class SensorHealth {
@@ -365,6 +382,7 @@ struct FusionCoreStatus {
   // rejection). Quality-gate rejects (HDOP/VDOP/fix-type/sats) and delay rejects
   // do NOT increment gnss_outliers, so this is the only place they are reported.
   GnssRejectionReason gnss_last_rejection_reason = GnssRejectionReason::NOT_PROCESSED;
+  MagRejectionReason mag_last_rejection_reason = MagRejectionReason::NOT_PROCESSED;
 
   // Stale-measurement rejections from inter-sensor clock skew: this sensor's
   // stamps run more than max_measurement_delay behind the filter clock while
@@ -465,6 +483,7 @@ public:
   double last_position_correction() const { return ukf_.last_position_correction(); }
   FusionCoreStatus   get_status()     const;
   const GnssFixDebug& get_gnss_debug() const { return gnss_debug_; }
+  const MagnetometerDebug& get_magnetometer_debug() const { return mag_debug_; }
   void               reset();
   bool               is_initialized()    const { return initialized_; }
   bool               is_heading_valid()  const { return heading_validated_; }
@@ -564,6 +583,7 @@ private:
 
   // Per-fix observability: updated on every update_gnss() call
   GnssFixDebug gnss_debug_;
+  MagnetometerDebug mag_debug_;
 
   // Last accepted innovation norms per sensor: updated on each accepted update
   double last_gnss_innovation_norm_    = 0.0;
@@ -575,6 +595,8 @@ private:
   bool gnss_in_coast_            = false;
   // Persists the reason of the last rejected GNSS fix, for status reporting.
   GnssRejectionReason last_gnss_rejection_reason_ = GnssRejectionReason::NOT_PROCESSED;
+  // Persists the reason of the last rejected magnetometer reading.
+  MagRejectionReason last_mag_rejection_reason_ = MagRejectionReason::NOT_PROCESSED;
 
   // Inter-sensor clock-skew protection. Raw per-stream stamps (recorded whether
   // or not the measurement was accepted, unlike last_*_time_ which only tracks

--- a/fusioncore_core/src/fusioncore.cpp
+++ b/fusioncore_core/src/fusioncore.cpp
@@ -149,7 +149,9 @@ void FusionCore::init(const State& initial_state, double timestamp_seconds) {
 
   // Reset observability state
   gnss_debug_                    = GnssFixDebug{};
+  mag_debug_                     = MagnetometerDebug{};
   last_gnss_rejection_reason_    = GnssRejectionReason::NOT_PROCESSED;
+  last_mag_rejection_reason_     = MagRejectionReason::NOT_PROCESSED;
   last_gnss_innovation_norm_     = 0.0;
   last_imu_innovation_norm_      = 0.0;
   last_encoder_innovation_norm_  = 0.0;
@@ -196,7 +198,9 @@ void FusionCore::reset() {
   ukf_.set_gyro_bias_noise_scale(1.0);
 
   gnss_debug_                   = GnssFixDebug{};
+  mag_debug_                    = MagnetometerDebug{};
   last_gnss_rejection_reason_   = GnssRejectionReason::NOT_PROCESSED;
+  last_mag_rejection_reason_    = MagRejectionReason::NOT_PROCESSED;
   last_gnss_innovation_norm_    = 0.0;
   last_imu_innovation_norm_     = 0.0;
   last_encoder_innovation_norm_ = 0.0;
@@ -1302,6 +1306,7 @@ FusionCoreStatus FusionCore::get_status() const {
   status.gnss_in_coast           = gnss_in_coast_;
   status.gnss_consecutive_rejects = gnss_consecutive_rejects_;
   status.gnss_last_rejection_reason = last_gnss_rejection_reason_;
+  status.mag_last_rejection_reason = last_mag_rejection_reason_;
 
   // Inter-sensor clock-skew rejections
   status.imu_stale_rejects     = imu_stale_rejects_;
@@ -1407,6 +1412,12 @@ bool FusionCore::update_magnetometer(
   if (!initialized_)
     throw std::runtime_error("FusionCore: update_magnetometer() called before init()");
 
+  mag_debug_ = MagnetometerDebug{};
+  mag_debug_.chi2_threshold = config_.mag.chi2_threshold;
+  const Eigen::Vector3d corrected_field =
+    config_.mag.soft_iron * (Eigen::Vector3d(mx, my, mz) - config_.mag.hard_iron);
+  mag_debug_.measured_field = corrected_field.norm();
+
   if (reject_stale_from_skew(timestamp_seconds, last_mag_raw_stamp_, mag_stale_rejects_))
     return false;
 
@@ -1418,6 +1429,8 @@ bool FusionCore::update_magnetometer(
   // catch. See sensors::mag_field_disturbed. Disabled when field_strength <= 0.
   if (sensors::mag_field_disturbed(mx, my, mz, config_.mag)) {
     ++mag_outliers_;
+    mag_debug_.reason = MagRejectionReason::FIELD_MAGNITUDE;
+    last_mag_rejection_reason_ = mag_debug_.reason;
     return false;
   }
 
@@ -1445,8 +1458,12 @@ bool FusionCore::update_magnetometer(
     sensors::GnssHdgNoiseMatrix S;
     ukf_.predict_measurement<sensors::GNSS_HDG_DIM>(
       z, sensors::gnss_hdg_measurement_function, R, innov_pre, S, MAG_ANGLE_DIMS);
-    if (is_outlier<sensors::GNSS_HDG_DIM>(innov_pre, S, config_.mag.chi2_threshold)) {
+    const double mahalanobis_sq = innov_pre.dot(S.ldlt().solve(innov_pre));
+    mag_debug_.mahalanobis_sq = mahalanobis_sq;
+    if (mahalanobis_sq > config_.mag.chi2_threshold) {
       ++mag_outliers_;
+      mag_debug_.reason = MagRejectionReason::CHI2_FAILED;
+      last_mag_rejection_reason_ = mag_debug_.reason;
       return false;
     }
   }
@@ -1466,6 +1483,8 @@ bool FusionCore::update_magnetometer(
 
   last_mag_time_ = timestamp_seconds;
   ++update_count_;
+  mag_debug_.accepted = true;
+  mag_debug_.reason = MagRejectionReason::ACCEPTED;
   return true;
 }
 

--- a/fusioncore_core/tests/test_magnetometer.cpp
+++ b/fusioncore_core/tests/test_magnetometer.cpp
@@ -155,6 +155,10 @@ TEST(MagnetometerTest, Chi2GateRejectsOutlier) {
   // Filter is at yaw=0. Feed a pi/2 reading with noise_rad=0.001: huge outlier.
   bool accepted = fc.update_magnetometer(0.01, 1.0, 0.0, 0.0);  // yaw=pi/2
   EXPECT_FALSE(accepted);
+  EXPECT_EQ(fc.get_magnetometer_debug().reason, MagRejectionReason::CHI2_FAILED);
+  EXPECT_GT(fc.get_magnetometer_debug().mahalanobis_sq,
+            fc.get_magnetometer_debug().chi2_threshold);
+  EXPECT_EQ(fc.get_status().mag_last_rejection_reason, MagRejectionReason::CHI2_FAILED);
 }
 
 // ─── Test 10: heading_source set to MAGNETOMETER after first update ───────────
@@ -251,6 +255,9 @@ TEST(MagnetometerTest, DisturbedFieldRejected) {
 
   EXPECT_TRUE (fc.update_magnetometer(0.01, 0.0, 1.0, 0.0));  // clean, accepted
   EXPECT_FALSE(fc.update_magnetometer(0.02, 0.0, 1.6, 0.0));  // 60% high, rejected
+  EXPECT_EQ(fc.get_magnetometer_debug().reason, MagRejectionReason::FIELD_MAGNITUDE);
+  EXPECT_NEAR(fc.get_magnetometer_debug().measured_field, 1.6, 1e-9);
+  EXPECT_EQ(fc.get_status().mag_last_rejection_reason, MagRejectionReason::FIELD_MAGNITUDE);
 }
 
 // ─── Test 15: magnetometer bounds heading drift from wheel slip in a blackout ─

--- a/fusioncore_ros/msg/FilterHealth.msg
+++ b/fusioncore_ros/msg/FilterHealth.msg
@@ -29,6 +29,10 @@ int32 gnss_consecutive_rejects
 # gnss_outlier_count, so this is the only field that reveals why a fix was dropped.
 string gnss_last_reject_reason
 
+# Reason the most recent magnetometer reading was rejected (empty until the first reading):
+# CHI2_FAILED | FIELD_MAGNITUDE
+string mag_last_reject_reason
+
 # Distance traveled since init (meters): heading observable above 5m
 float64 distance_traveled_m
 

--- a/fusioncore_ros/src/fusion_node.cpp
+++ b/fusioncore_ros/src/fusion_node.cpp
@@ -2486,8 +2486,10 @@ private:
       msg->magnetic_field.y,
       msg->magnetic_field.z);
     if (!accepted) {
+      const auto& debug = fc_->get_magnetometer_debug();
       RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000,
-        "Magnetometer heading update rejected (chi2 gate)");
+        "Magnetometer heading update rejected (%s)",
+        mag_reason_str(debug.reason).c_str());
     }
   }
 
@@ -2512,6 +2514,17 @@ private:
       case fusioncore::GnssRejectionReason::SIGMA_XY_HIGH:   return "SIGMA_XY_HIGH";
       case fusioncore::GnssRejectionReason::SIGMA_Z_HIGH:    return "SIGMA_Z_HIGH";
       case fusioncore::GnssRejectionReason::NOT_PROCESSED:   return "NOT_PROCESSED";
+    }
+    return "NOT_PROCESSED";
+  }
+
+  static std::string mag_reason_str(fusioncore::MagRejectionReason r)
+  {
+    switch (r) {
+      case fusioncore::MagRejectionReason::CHI2_FAILED:     return "CHI2_FAILED";
+      case fusioncore::MagRejectionReason::FIELD_MAGNITUDE: return "FIELD_MAGNITUDE";
+      case fusioncore::MagRejectionReason::NOT_PROCESSED:   return "NOT_PROCESSED";
+      case fusioncore::MagRejectionReason::ACCEPTED:        return "ACCEPTED";
     }
     return "NOT_PROCESSED";
   }
@@ -2899,6 +2912,11 @@ private:
       fh.gnss_in_coast           = status.gnss_in_coast;
       fh.gnss_consecutive_rejects = status.gnss_consecutive_rejects;
       fh.gnss_last_reject_reason = gnss_reject_str(status.gnss_last_rejection_reason);
+      fh.mag_last_reject_reason = mag_reason_str(status.mag_last_rejection_reason);
+      if (status.mag_last_rejection_reason == fusioncore::MagRejectionReason::NOT_PROCESSED ||
+          status.mag_last_rejection_reason == fusioncore::MagRejectionReason::ACCEPTED) {
+        fh.mag_last_reject_reason.clear();
+      }
 
       fh.distance_traveled_m = status.distance_traveled;
 


### PR DESCRIPTION
#82
Problem Fixed: Updated the magnetometer subsystem in fusioncore to separate into two independent rejection gates (the χ 
2
  gate and the field magnitude gate) and report both rejection reasons properly.
What Was Changed:
Updated the rejection reasons in fusioncore.hpp to include independent states for the χ 
2
  gate and field magnitude gate instead of generic single-counter tracking.
Added a debug struct (mag_last_reject_reason) mirroring the GNSS pattern to track individual rejection metrics such as Mahalanobis distance, threshold, and measured field values.
Updated update_magnetometer() in fusioncore/src/fusioncore.cpp to evaluate and assign the correct rejection path independently.
Exposed the new magnetometer rejection status to match existing health telemetry reporting patterns.