### PR TITLE
ci: run the quick-start smoke test on supported ROS distros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,12 @@ jobs:
             --cmake-args -DBUILD_TESTING=ON \
             --event-handlers console_cohesion+
 
+      - name: Run quick-start smoke test
+        run: |
+          source /opt/ros/${{ matrix.ros_distro }}/setup.sh
+          source install/local_setup.bash
+          bash tools/quick_test.sh
+
       - name: Test
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.sh


### PR DESCRIPTION
Closes #77.

Runs the documented quick-start smoke test after each Jazzy and Humble matrix build, with both the ROS distro and built workspace sourced first. A non-zero result now fails CI before the unit-test step.

Validation: `actionlint .github/workflows/ci.yml`, `git diff --check`, and a structural check covering both matrix distros and step ordering. The ROS smoke test itself will run in CI.

AI-assisted with Codex; the workflow change and issue requirements were reviewed manually.
