### PR TITLE
tools: warn on unsafe config parameter values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Check shipped configs against declared parameters
         run: python3 tools/check_config_params.py --quiet
 
+      - name: Test config checker rules
+        run: python3 -m unittest tools/test_check_config_params.py
+
       - name: Install rosdep dependencies
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.sh

--- a/tools/check_config_params.py
+++ b/tools/check_config_params.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail if a shipped config YAML sets a parameter the node never declares.
+"""Check shipped config YAMLs for undeclared or unsafe parameters.
 
 ROS 2 silently ignores a parameter a node did not declare. No error, no warning,
 nothing in the log: the value simply has no effect, forever. A typo like
@@ -10,12 +10,14 @@ gate for months (issue #79) for exactly this reason.
 Usage:
     python3 tools/check_config_params.py [--quiet]
 
-Exit 0 if every config is clean, 1 otherwise.
+Warnings describe hardware-dependent settings and do not fail CI. Errors describe
+settings the documented filter model says are unsafe and exit 1.
 """
 import glob
 import os
 import re
 import sys
+import textwrap
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 NODE = os.path.join(ROOT, "fusioncore_ros", "src", "fusion_node.cpp")
@@ -31,6 +33,32 @@ CONFIG_GLOBS = [
     "docs/**/*.yaml",
 ]
 
+# A 95% chi-squared gate is the tightest supported setting. The defaults use
+# 99.9%; this lower floor still leaves room for deliberately tighter shipped
+# configurations while rejecting settings known to reject ordinary sensor noise.
+OUTLIER_THRESHOLD_MINIMUMS = {
+    "outlier_threshold_gnss": (7.81, "chi2(3, 0.95)",
+                               "At 7.0, normal GNSS noise tripped the gate in a field test."),
+    "outlier_threshold_imu": (12.59, "chi2(6, 0.95)",
+                              "A lower threshold rejects more than 5% of ordinary 6-DOF updates."),
+    "outlier_threshold_enc": (7.81, "chi2(3, 0.95)",
+                              "A lower threshold rejects more than 5% of ordinary 3-DOF updates."),
+    "outlier_threshold_hdg": (3.84, "chi2(1, 0.95)",
+                              "A lower threshold rejects more than 5% of ordinary heading updates."),
+    "outlier_threshold_vslam": (12.59, "chi2(6, 0.95)",
+                                "A lower threshold rejects more than 5% of ordinary 6-DOF updates."),
+}
+
+# Values used by the node when a config does not spell the parameter out. They
+# let relationship rules reason about an effective configuration without
+# duplicating every node default here.
+RELATIONSHIP_DEFAULTS = {
+    "outlier_rejection": True,
+    "magnetometer.enabled": False,
+    "gnss.max_speed_sigma_k": 5.0,
+    "gnss.max_sigma_xy": 25.0,
+}
+
 
 def declared_parameters(path):
     """Every name passed to declare_parameter() in the node."""
@@ -42,7 +70,7 @@ def declared_parameters(path):
 
 
 def config_parameters(path):
-    """Parameter keys under a node's ros__parameters, as dotted names.
+    """Parameters under a node's ros__parameters as (name, line, value).
 
     Hand-rolled rather than yaml.safe_load because these files are heavily
     commented and the comments carry the reasoning: keeping the parser dumb means
@@ -85,30 +113,136 @@ def config_parameters(path):
             continue
         if line.strip().startswith("-"):    # list continuation
             continue
-        out.append((".".join([k for _, k in stack] + [key]), n))
+        out.append((".".join([k for _, k in stack] + [key]), n, value))
     return out
+
+
+def scalar(value):
+    """Parse the scalar forms this checker needs without adding PyYAML."""
+    value = re.split(r"\s+#", value, maxsplit=1)[0].strip()
+    if value.lower() == "true":
+        return True
+    if value.lower() == "false":
+        return False
+    try:
+        return float(value)
+    except ValueError:
+        return value.strip("\"'")
+
+
+def number(values, name):
+    """Return a configured numeric value, or None for a non-number/missing key."""
+    value = values.get(name, (RELATIONSHIP_DEFAULTS.get(name), None, None))[0]
+    return value if isinstance(value, float) else None
+
+
+def value_findings(parameters):
+    """Return (severity, name, line, raw_value, message) value findings.
+
+    The rules are intentionally split into strict errors and advisory warnings:
+    the chi-squared floors are documented mathematical limits, whereas GNSS
+    consistency depends on the specific receiver and environment.
+    """
+    values = {name: (scalar(raw), line, raw) for name, line, raw in parameters}
+    findings = []
+
+    if values.get("outlier_rejection", (True, None, None))[0]:
+        for name, (minimum, distribution, evidence) in OUTLIER_THRESHOLD_MINIMUMS.items():
+            configured = values.get(name)
+            configured_number = number(values, name)
+            if configured and configured_number is not None and configured_number < minimum:
+                _, line, raw = configured
+                findings.append((
+                    "ERROR", name, line, raw,
+                    f"This is below {distribution}, the lowest supported outlier gate. "
+                    "Normal sensor noise will trip the gate and measurements will be "
+                    f"rejected. {evidence}",
+                ))
+
+    continuity = number(values, "gnss.continuity_max_m")
+    if continuity is not None and 0.0 < continuity < 3.0:
+        _, line, raw = values["gnss.continuity_max_m"]
+        findings.append((
+            "WARNING", "gnss.continuity_max_m", line, raw,
+            "This is low enough to reject good GNSS fixes. Across 2,361 fixes from "
+            "seven field logs, 3.0 m rejected none while 2.0 m rejected 12 good fixes. "
+            "Measure your receiver's fix-to-fix consistency before tightening it.",
+        ))
+
+    field_strength = number(values, "magnetometer.field_strength")
+    if field_strength is not None and field_strength != 0.0 and not values.get(
+            "magnetometer.enabled", (False, None, None))[0]:
+        _, line, raw = values["magnetometer.field_strength"]
+        findings.append((
+            "WARNING", "magnetometer.field_strength", line, raw,
+            "The magnetic-field gate is configured but never runs because "
+            "magnetometer.enabled is false.",
+        ))
+
+    max_speed = number(values, "gnss.max_speed")
+    sigma_k = number(values, "gnss.max_speed_sigma_k")
+    if max_speed is not None and max_speed > 0.0 and sigma_k is not None and sigma_k <= 0.0:
+        _, line, raw = values["gnss.max_speed_sigma_k"]
+        findings.append((
+            "WARNING", "gnss.max_speed_sigma_k", line, raw,
+            "With gnss.max_speed enabled this makes the jump gate absolute metres, "
+            "not receiver-sigma-scaled. On a u-blox M9N, max_speed 2.0 with the "
+            "default margin rejected 157 of 500 good fixes and worsened loop closure "
+            "from 2.62 m to 7.27 m.",
+        ))
+
+    outlier_sigma = number(values, "gnss.outlier_sigma_xy")
+    max_sigma = number(values, "gnss.max_sigma_xy")
+    if outlier_sigma is not None and outlier_sigma > 0.0 and max_sigma is not None \
+            and outlier_sigma >= max_sigma:
+        _, line, raw = values["gnss.outlier_sigma_xy"]
+        findings.append((
+            "WARNING", "gnss.outlier_sigma_xy", line, raw,
+            "This cannot tighten the outlier gate: every accepted covariance-reporting "
+            "fix has sigma no larger than gnss.max_sigma_xy. Set this to the receiver's "
+            "measured short-term fix-to-fix consistency, which must be smaller than its "
+            "reported sigma. On a 3.24 m receiver, 5.0 loosened the rejection threshold "
+            "from 26 m to 30 m.",
+        ))
+
+    return findings
+
+
+def print_finding(severity, name, line, raw, message):
+    print(f"  line {line:4d}  {name}: {raw}")
+    print(textwrap.fill(f"{severity}: {message}", width=84, initial_indent="             ",
+                        subsequent_indent="             "))
 
 
 def main():
     quiet = "--quiet" in sys.argv
     declared = declared_parameters(NODE)
-    files, bad = 0, 0
+    files, errors, warnings = 0, 0, 0
     for pattern in CONFIG_GLOBS:
         for path in sorted(glob.glob(os.path.join(ROOT, pattern), recursive=True)):
             rel = os.path.relpath(path, ROOT)
-            unknown = [(k, n) for k, n in config_parameters(path) if k not in declared]
+            parameters = config_parameters(path)
+            unknown = [(k, n) for k, n, _ in parameters if k not in declared]
+            findings = value_findings(parameters)
             files += 1
-            if unknown:
-                bad += 1
+            if unknown or findings:
                 print(f"\n{rel}")
                 for k, n in unknown:
+                    errors += 1
                     near = sorted(d for d in declared if d.split(".")[-1] == k.split(".")[-1])
                     hint = f"   did you mean {near[0]}?" if near else ""
                     print(f"  line {n:4d}  {k}  NOT DECLARED BY THE NODE{hint}")
+                for finding in findings:
+                    if finding[0] == "ERROR":
+                        errors += 1
+                    else:
+                        warnings += 1
+                    print_finding(*finding)
             elif not quiet:
                 print(f"ok  {rel}")
-    print(f"\n{files} config files checked, {bad} with undeclared parameters")
-    return 1 if bad else 0
+    print(f"\n{files} config files checked, {errors} errors, {warnings} warnings")
+    return 1 if errors else 0
 
 
-sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_check_config_params.py
+++ b/tools/test_check_config_params.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Unit tests for the value rules in check_config_params.py."""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import check_config_params
+
+
+def findings_for(*parameters):
+    return check_config_params.value_findings(parameters)
+
+
+class ValueRulesTest(unittest.TestCase):
+    def test_outlier_threshold_below_floor_is_an_error(self):
+        findings = findings_for(
+            ("outlier_threshold_gnss", 10, "7.0"),
+        )
+
+        self.assertEqual("ERROR", findings[0][0])
+        self.assertIn("chi2(3, 0.95)", findings[0][4])
+
+    def test_documented_tightest_gnss_gate_is_allowed(self):
+        self.assertEqual([], findings_for(("outlier_threshold_gnss", 10, "7.81")))
+
+    def test_continuity_floor_is_advisory(self):
+        findings = findings_for(("gnss.continuity_max_m", 10, "2.0"))
+
+        self.assertEqual("WARNING", findings[0][0])
+        self.assertIn("2,361 fixes", findings[0][4])
+
+    def test_field_strength_requires_magnetometer(self):
+        findings = findings_for(
+            ("magnetometer.enabled", 2, "false"),
+            ("magnetometer.field_strength", 3, "48.0"),
+        )
+
+        self.assertEqual("WARNING", findings[0][0])
+        self.assertIn("never runs", findings[0][4])
+
+    def test_sigma_scaled_speed_gate_is_not_warned(self):
+        self.assertEqual([], findings_for(
+            ("gnss.max_speed", 2, "2.0"),
+            ("gnss.max_speed_sigma_k", 3, "5.0"),
+        ))
+
+    def test_absolute_speed_gate_warns(self):
+        findings = findings_for(
+            ("gnss.max_speed", 2, "2.0"),
+            ("gnss.max_speed_sigma_k", 3, "0.0"),
+        )
+
+        self.assertEqual("WARNING", findings[0][0])
+        self.assertIn("157 of 500", findings[0][4])
+
+    def test_outlier_sigma_must_be_smaller_than_sigma_quality_limit(self):
+        findings = findings_for(
+            ("gnss.max_sigma_xy", 2, "3.24"),
+            ("gnss.outlier_sigma_xy", 3, "5.0"),
+        )
+
+        self.assertEqual("WARNING", findings[0][0])
+        self.assertIn("26 m to 30 m", findings[0][4])
+
+    def test_disabled_outlier_rejection_skips_threshold_rules(self):
+        self.assertEqual([], findings_for(
+            ("outlier_rejection", 2, "false"),
+            ("outlier_threshold_gnss", 3, "7.0"),
+        ))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extends tools/check_config_params.py beyond undeclared parameter names to detect
  known silent misconfigurations in shipped FusionCore YAML files.

  - Fails on outlier thresholds below the supported 95% chi-squared floor.
  - Warns, without failing CI, about hardware-dependent risky settings:
      - gnss.continuity_max_m below 3.0 m
      - magnetic field strength configured while the magnetometer is disabled
      - enabled GNSS speed gate with no receiver-sigma scaling
      - gnss.outlier_sigma_xy at or above gnss.max_sigma_xy, which cannot tighten the
        gate

  - Diagnostics include source line, configured value, rationale, and documented field
    evidence.

  - Adds standalone unit tests and runs them in CI before ROS dependency installation/
    build.