### PR TITLE
tools: add --json to nis_from_bag.py so the numbers can be scripted

### DIFF
--- a/tools/nis_from_bag.py
+++ b/tools/nis_from_bag.py
@@ -24,7 +24,13 @@ For a filter whose covariance is honest, NIS averages the measurement dimension,
 
 Usage:
     python3 tools/nis_from_bag.py <bag_dir> [more bags ...]
+    python3 tools/nis_from_bag.py --json <bag_dir> [more bags ...]
+
+--json prints one JSON object per bag (JSON Lines) instead of the prose, with
+the same numbers, so a script or a CI job can track them across runs.
 """
+import argparse
+import json
 import sys
 import os
 import statistics
@@ -135,19 +141,22 @@ def pct(values, q):
     return values[idx]
 
 
-def report(bag):
+def analyze(bag):
+    """Every number the report prints, as one dict, so prose and --json agree.
+
+    A bag that cannot be measured comes back as {"bag", "error"} rather than
+    raising, so one bad bag does not stop the rest. "nis", "health" and "navsat"
+    are None when that part was not recorded.
+    """
     name = os.path.basename(os.path.normpath(bag))
     try:
         gnss, health = read(bag)
-    except Exception as exc:                      # one unreadable bag must not
-        print("  %s: could not be read (%s)" % (name, exc))   # stop the rest
-        return
+    except Exception as exc:
+        return {"bag": name, "error": "could not be read (%s)" % exc}
     if gnss is None:
-        print("  %s: no %s recorded, nothing to measure" % (name, GNSS_TOPIC))
-        return
+        return {"bag": name, "error": "no %s recorded, nothing to measure" % GNSS_TOPIC}
     if not gnss:
-        print("  %s: %s is empty" % (name, GNSS_TOPIC))
-        return
+        return {"bag": name, "error": "%s is empty" % GNSS_TOPIC}
 
     # mahalanobis_sq is -1 when a quality gate failed before the chi2 test ran,
     # so those fixes carry no NIS to report.
@@ -155,20 +164,62 @@ def report(bag):
     reasons = {}
     for m in gnss:
         reasons[m.rejection_reason] = reasons.get(m.rejection_reason, 0) + 1
-    threshold = gnss[-1].chi2_threshold
 
-    print("\n=== %s ===" % name)
-    print("  fixes %d, accepted %d" % (len(gnss), sum(1 for m in gnss if m.accepted)))
-    for reason, count in sorted(reasons.items(), key=lambda kv: -kv[1]):
-        print("    %-18s %4d  (%.0f%%)" % (reason, count, 100.0 * count / len(gnss)))
+    out = {
+        "bag": name,
+        "fixes": len(gnss),
+        "accepted": sum(1 for m in gnss if m.accepted),
+        "rejection_reasons": reasons,
+        "chi2_threshold": gnss[-1].chi2_threshold,
+        "nis": None,
+        "health": None,
+        "navsat": None,
+    }
+    if nis:
+        out["nis"] = {
+            "samples": len(nis),
+            "median": statistics.median(nis),
+            "mean": statistics.mean(nis),
+            "p90": pct(nis, 0.90),
+            "max": nis[-1],
+            "expected": EXPECTED_NIS,
+        }
+    if health:
+        out["health"] = {
+            "position_sigma_median_m": statistics.median(m.position_sigma_x for m in health),
+            "heading_sigma_median_deg": statistics.median(m.heading_sigma_deg for m in health),
+            "heading_sources": sorted({m.heading_source for m in health}),
+        }
+    nav = read_navsat(bag)
+    if nav:
+        topic, declared, observed, expected = nav
+        out["navsat"] = {
+            "topic": topic,
+            "declared_sigma_m": declared,
+            "observed_d2_median_m": observed,
+            "expected_d2_median_m": expected,
+        }
+    return out
 
+
+def print_report(s):
+    if "error" in s:
+        print("  %s: %s" % (s["bag"], s["error"]))
+        return
+
+    print("\n=== %s ===" % s["bag"])
+    print("  fixes %d, accepted %d" % (s["fixes"], s["accepted"]))
+    for reason, count in sorted(s["rejection_reasons"].items(), key=lambda kv: -kv[1]):
+        print("    %-18s %4d  (%.0f%%)" % (reason, count, 100.0 * count / s["fixes"]))
+
+    nis = s["nis"]
     if not nis:
         print("  no NIS samples: every fix failed a quality gate before the chi2 test")
         return
 
-    med = statistics.median(nis)
+    med = nis["median"]
     print("  NIS median %.2f   mean %.2f   p90 %.2f   max %.2f   (honest is %.1f)"
-          % (med, statistics.mean(nis), pct(nis, 0.90), nis[-1], EXPECTED_NIS))
+          % (med, nis["mean"], nis["p90"], nis["max"], EXPECTED_NIS))
 
     if med > 3.0 * EXPECTED_NIS:
         print("  OVERCONFIDENT by %.0fx: the filter trusts itself more than it has "
@@ -179,27 +230,26 @@ def report(bag):
               "warrant." % (EXPECTED_NIS / med))
         print("  Consequence: the gain is too high, so the filter tracks GNSS noise "
               "instead of smoothing it.")
-        if nis[-1] < threshold:
+        if nis["max"] < s["chi2_threshold"]:
             print("  Consequence: outlier rejection is INERT. The chi2 threshold is "
                   "%.2f and the largest NIS in this whole run was %.2f, so no fix "
-                  "could ever have been rejected by it." % (threshold, nis[-1]))
+                  "could ever have been rejected by it." % (s["chi2_threshold"], nis["max"]))
     else:
         print("  Covariance is consistent with the errors being made.")
 
+    health = s["health"]
     if health:
-        hdg = sorted(m.heading_sigma_deg for m in health)
-        pos = sorted(m.position_sigma_x for m in health)
-        print("  filter position 1-sigma: median %.2f m" % statistics.median(pos))
+        print("  filter position 1-sigma: median %.2f m" % health["position_sigma_median_m"])
         print("  heading 1-sigma: median %.0f deg, sources %s"
-              % (statistics.median(hdg), sorted({m.heading_source for m in health})))
-        if statistics.median(hdg) > 45.0:
+              % (health["heading_sigma_median_deg"], health["heading_sources"]))
+        if health["heading_sigma_median_deg"] > 45.0:
             print("  Heading is effectively unknown, which inflates the position "
                   "covariance and pushes NIS down.")
 
-    nav = read_navsat(bag)
+    nav = s["navsat"]
     if nav:
-        topic, declared, observed, expected = nav
-        print("  receiver on %s declares %.2f m 1-sigma" % (topic, declared))
+        observed, expected = nav["observed_d2_median_m"], nav["expected_d2_median_m"]
+        print("  receiver on %s declares %.2f m 1-sigma" % (nav["topic"], nav["declared_sigma_m"]))
         print("    fix-to-fix scatter implies far less: median second difference "
               "%.3f m against the %.1f m that declared figure would produce"
               % (observed, expected))
@@ -215,11 +265,20 @@ def report(bag):
 
 
 def main():
-    if len(sys.argv) < 2:
-        sys.exit(__doc__)
-    for bag in sys.argv[1:]:
-        report(bag)
-    print()
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("bags", nargs="+", metavar="bag_dir")
+    ap.add_argument("--json", action="store_true",
+                    help="print one JSON object per bag (JSON Lines) instead of the prose")
+    args = ap.parse_args()
+    for bag in args.bags:
+        stats = analyze(bag)
+        if args.json:
+            print(json.dumps(stats))
+        else:
+            print_report(stats)
+    if not args.json:
+        print()
 
 
 if __name__ == "__main__":

--- a/tools/test_nis_from_bag.py
+++ b/tools/test_nis_from_bag.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Tests for nis_from_bag.py: --json must carry the same numbers the prose prints.
+
+No ROS needed. The bag readers are replaced with synthetic messages, so this
+only checks the aggregation and the two output paths, not rosbag2 itself.
+Run with: python3 -m unittest tools/test_nis_from_bag.py
+"""
+import contextlib
+import io
+import json
+import os
+import sys
+import types
+import unittest
+from types import SimpleNamespace as Msg
+from unittest import mock
+
+# nis_from_bag exits at import time without a sourced ROS 2 environment.
+# Nothing below reads a bag, so stand in for the three imports it checks.
+for _name, _attr in (("rosbag2_py", None), ("rclpy", None), ("rosidl_runtime_py", None),
+                     ("rclpy.serialization", "deserialize_message"),
+                     ("rosidl_runtime_py.utilities", "get_message")):
+    if _name not in sys.modules:
+        sys.modules[_name] = types.ModuleType(_name)
+        if _attr:
+            setattr(sys.modules[_name], _attr, None)
+
+sys.path.insert(0, os.path.dirname(__file__))
+import nis_from_bag  # noqa: E402
+
+
+def gnss(mahalanobis_sq, reason, accepted):
+    return Msg(mahalanobis_sq=mahalanobis_sq, rejection_reason=reason,
+               accepted=accepted, chi2_threshold=16.27)
+
+
+# NIS samples sorted: 1, 2, 4, 30 -> median 3.0, mean 9.25, p90 4.0, max 30.0.
+# The -1 fix failed a quality gate and carries no NIS.
+GNSS = [gnss(1.0, "ACCEPTED", True), gnss(2.0, "ACCEPTED", True),
+        gnss(4.0, "ACCEPTED", True), gnss(30.0, "CHI2_FAILED", False),
+        gnss(-1.0, "HDOP_HIGH", False)]
+HEALTH = [Msg(position_sigma_x=0.5, heading_sigma_deg=10.0, heading_source="GPS_TRACK"),
+          Msg(position_sigma_x=0.3, heading_sigma_deg=90.0, heading_source="NONE"),
+          Msg(position_sigma_x=0.4, heading_sigma_deg=20.0, heading_source="GPS_TRACK")]
+NAVSAT = ("/gps/fix", 2.5, 0.03, 7.21)
+
+
+def run_main(*argv):
+    out = io.StringIO()
+    with mock.patch.object(sys, "argv", ["nis_from_bag.py", *argv]), \
+            contextlib.redirect_stdout(out):
+        nis_from_bag.main()
+    return out.getvalue()
+
+
+@mock.patch.object(nis_from_bag, "read_navsat", lambda bag: NAVSAT)
+@mock.patch.object(nis_from_bag, "read", lambda bag: (GNSS, HEALTH))
+class NisFromBagTest(unittest.TestCase):
+    def test_analyze_reports_the_numbers_the_prose_prints(self):
+        s = nis_from_bag.analyze("/bags/run1/")
+        self.assertEqual("run1", s["bag"])
+        self.assertEqual((5, 3), (s["fixes"], s["accepted"]))
+        self.assertEqual({"ACCEPTED": 3, "CHI2_FAILED": 1, "HDOP_HIGH": 1}, s["rejection_reasons"])
+        self.assertEqual(16.27, s["chi2_threshold"])
+        self.assertEqual({"samples": 4, "median": 3.0, "mean": 9.25, "p90": 4.0,
+                          "max": 30.0, "expected": 3.0}, s["nis"])
+        self.assertEqual({"position_sigma_median_m": 0.4, "heading_sigma_median_deg": 20.0,
+                          "heading_sources": ["GPS_TRACK", "NONE"]}, s["health"])
+        self.assertEqual({"topic": "/gps/fix", "declared_sigma_m": 2.5,
+                          "observed_d2_median_m": 0.03, "expected_d2_median_m": 7.21},
+                         s["navsat"])
+
+    def test_json_is_one_object_per_bag_and_a_bad_bag_does_not_stop_the_rest(self):
+        def read(bag):
+            if bag == "broken":
+                raise RuntimeError("no such file")
+            return GNSS, HEALTH
+
+        with mock.patch.object(nis_from_bag, "read", read):
+            lines = run_main("--json", "broken", "/bags/run1").splitlines()
+        self.assertEqual(2, len(lines))
+        bad, good = (json.loads(line) for line in lines)
+        self.assertEqual({"bag": "broken", "error": "could not be read (no such file)"}, bad)
+        self.assertEqual(nis_from_bag.analyze("/bags/run1"), good)
+
+    def test_prose_stays_the_default(self):
+        out = run_main("/bags/run1")
+        self.assertIn("=== run1 ===", out)
+        self.assertIn("    ACCEPTED              3  (60%)", out)
+        self.assertIn("NIS median 3.00   mean 9.25   p90 4.00   max 30.00   (honest is 3.0)", out)
+        self.assertIn("Covariance is consistent with the errors being made.", out)
+        self.assertIn("heading 1-sigma: median 20 deg, sources ['GPS_TRACK', 'NONE']", out)
+        self.assertIn("receiver on /gps/fix declares 2.50 m 1-sigma", out)
+
+    def test_no_nis_samples_when_every_fix_failed_a_quality_gate(self):
+        gated = [m for m in GNSS if m.mahalanobis_sq < 0.0]
+        with mock.patch.object(nis_from_bag, "read", lambda bag: (gated, [])), \
+                mock.patch.object(nis_from_bag, "read_navsat", lambda bag: None):
+            s = nis_from_bag.analyze("run")
+            out = run_main("run")
+        self.assertEqual({"nis": None, "health": None, "navsat": None},
+                         {k: s[k] for k in ("nis", "health", "navsat")})
+        self.assertIn("no NIS samples", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #84

`report()` is split into `analyze()`, which returns every number as one dict, and `print_report()`, which renders the existing prose from that dict. `main()` moves to `argparse`; the positional bag arguments work as before and prose stays the default.

`--json` prints one object per bag (JSON Lines, so `jq` reads it line by line without slurping):

```json
{"bag": "run1", "fixes": 5, "accepted": 3, "rejection_reasons": {"ACCEPTED": 3, "CHI2_FAILED": 1, "HDOP_HIGH": 1}, "chi2_threshold": 16.27, "nis": {"samples": 4, "median": 3.0, "mean": 9.25, "p90": 4.0, "max": 30.0, "expected": 3.0}, "health": {"position_sigma_median_m": 0.4, "heading_sigma_median_deg": 20.0, "heading_sources": ["GPS_TRACK", "NONE"]}, "navsat": {"topic": "/gps/fix", "declared_sigma_m": 2.5, "observed_d2_median_m": 0.03, "expected_d2_median_m": 7.21}}
```

`nis`, `health` and `navsat` are `null` when that part was not recorded, so the keys are stable for a script. A bag that cannot be measured comes out as `{"bag": ..., "error": ...}` so the line count still matches the bag count and one bad bag does not stop the rest, same as the prose. `nis.expected` is the constant 3.0 so a CI check can express "median within [expected/3, 3*expected]" without hard-coding it.

The numbers and how they are computed are untouched. I diffed the old `report()` against `print_report(analyze())` on synthetic messages across every branch (consistent, over/underconfident, inert gate, unknown heading, smoothing receiver, no health, no navsat, the three error paths) and the prose is byte-identical. One deliberate difference: `analyze()` reads the NavSat topic even when no fix reached the chi2 gate, where the prose used to return early, so `--json` still carries the declared-vs-observed comparison for such a bag. The prose output for that case is unchanged.

`tools/test_nis_from_bag.py` locks the JSON to the prose on synthetic messages and runs without ROS (`python3 -m unittest tools/test_nis_from_bag.py`, or pytest). I left CI alone since #100 is adding a tools test step; happy to fold this test into that step once it lands, or add one here if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
