### PR TITLE
Warn when a magnetometer parameter looks like microtesla instead of tesla

### DIFF
--- a/fusioncore_core/include/fusioncore/sensors/magnetometer.hpp
+++ b/fusioncore_core/include/fusioncore/sensors/magnetometer.hpp
@@ -76,6 +76,27 @@ inline bool mag_field_disturbed(
   return std::abs(m_c.norm() - p.field_strength) > p.field_tolerance * p.field_strength;
 }
 
+// Largest field magnitude that can plausibly be tesla. sensor_msgs/MagneticField
+// is tesla, so field_strength and hard_iron are tesla and Earth's total field is
+// roughly 2.5e-5 to 6.5e-5. Magnetometer datasheets and calibration tools nearly
+// always print microtesla, where the same field reads as about 50, so a value
+// entered in microtesla lands 1e6 too high. That is silent and total: every
+// reading then misses field_strength by a factor of a million, mag_field_disturbed
+// rejects all of them, and no heading comes out at all, which looks exactly like
+// a magnetometer that was never wired up.
+//
+// 1e-3 T (1000 uT) is deliberately loose: it only fires on an actual unit
+// mistake, never on an unusual but real field.
+constexpr double kMagPlausibleTeslaMax = 1.0e-3;
+
+// True when a tesla-valued magnetometer parameter is large enough that microtesla
+// is the likely explanation. 0.0 is the default for both field_strength (gate
+// disabled) and hard_iron (uncalibrated), so zero never flags.
+inline bool mag_value_looks_like_microtesla(double tesla)
+{
+  return tesla > kMagPlausibleTeslaMax;
+}
+
 // Apply hard/soft iron correction and tilt compensation to a raw magnetometer
 // reading, returning the heading in radians (ENU yaw convention: counterclockwise
 // from east, same as the UKF's quaternion-derived yaw).

--- a/fusioncore_core/tests/test_magnetometer.cpp
+++ b/fusioncore_core/tests/test_magnetometer.cpp
@@ -363,3 +363,37 @@ TEST(MagnetometerTest, ReportedFieldIsTheOneTheGateTested) {
   // report. -1 is the sentinel for that, and it must not read as a passing 0.
   EXPECT_LT(fc.get_magnetometer_debug().mahalanobis_sq, 0.0);
 }
+
+// ─── Test 16: microtesla-instead-of-tesla parameter detection ─────────────────
+// MagneticField is tesla, calibration tools print microtesla. Entering 50 for
+// what should be 5e-5 makes mag_field_disturbed reject every reading, so the
+// heading silently never appears. The node warns at configure time on this.
+
+TEST(MagnetometerTest, MicroteslaParameterLooksWrong) {
+  // Defaults must stay quiet: 0.0 means the gate is off / hard iron is
+  // uncalibrated, not that someone got the units wrong.
+  EXPECT_FALSE(mag_value_looks_like_microtesla(0.0));
+  EXPECT_FALSE(mag_value_looks_like_microtesla(MagParams{}.field_strength));
+  EXPECT_FALSE(mag_value_looks_like_microtesla(MagParams{}.hard_iron.norm()));
+
+  // Real Earth field in tesla, across the plausible span. None of these flag.
+  EXPECT_FALSE(mag_value_looks_like_microtesla(2.5e-5));
+  EXPECT_FALSE(mag_value_looks_like_microtesla(5.0e-5));
+  EXPECT_FALSE(mag_value_looks_like_microtesla(6.5e-5));
+
+  // The same fields typed in microtesla. Every one of these is the bug.
+  EXPECT_TRUE(mag_value_looks_like_microtesla(25.0));
+  EXPECT_TRUE(mag_value_looks_like_microtesla(50.0));
+  EXPECT_TRUE(mag_value_looks_like_microtesla(65.0));
+
+  // Loose by design: the threshold sits well above any real field, so an
+  // unusual-but-genuine tesla value is not second-guessed.
+  EXPECT_FALSE(mag_value_looks_like_microtesla(kMagPlausibleTeslaMax));
+  EXPECT_TRUE (mag_value_looks_like_microtesla(kMagPlausibleTeslaMax * 1.01));
+
+  // hard_iron is checked by magnitude, the way the node passes it.
+  EXPECT_FALSE(mag_value_looks_like_microtesla(
+    Eigen::Vector3d(1.2e-5, -3.0e-6, 8.0e-6).norm()));
+  EXPECT_TRUE (mag_value_looks_like_microtesla(
+    Eigen::Vector3d(12.0, -3.0, 8.0).norm()));
+}

--- a/fusioncore_ros/src/fusion_node.cpp
+++ b/fusioncore_ros/src/fusion_node.cpp
@@ -643,6 +643,30 @@ public:
       }
     }
 
+    // sensor_msgs/MagneticField is tesla, but calibration tools print microtesla.
+    // Entering microtesla here is silent and total: every reading misses the
+    // field-magnitude gate by a factor of a million and no heading comes out.
+    // Warn rather than fail, since an unusual value may still be deliberate.
+    if (fusioncore::sensors::mag_value_looks_like_microtesla(config.mag.field_strength)) {
+      RCLCPP_WARN(get_logger(),
+        "magnetometer.field_strength is %g, far above Earth's field of ~5e-5. "
+        "sensor_msgs/MagneticField is TESLA, so this is probably microtesla: "
+        "%g uT is %.2e T. Left as is, every magnetometer reading is rejected as "
+        "a magnetic disturbance and you get no heading at all.",
+        config.mag.field_strength, config.mag.field_strength,
+        config.mag.field_strength * 1e-6);
+    }
+
+    const double hard_iron_norm = config.mag.hard_iron.norm();
+    if (fusioncore::sensors::mag_value_looks_like_microtesla(hard_iron_norm)) {
+      RCLCPP_WARN(get_logger(),
+        "magnetometer.hard_iron has magnitude %g, far above Earth's field of "
+        "~5e-5. sensor_msgs/MagneticField is TESLA, so these are probably "
+        "microtesla: scale the vector by 1e-6. Left as is, the bias correction "
+        "swamps every reading and the heading is meaningless.",
+        hard_iron_norm);
+    }
+
     if (mag_enabled_) {
       RCLCPP_INFO(get_logger(),
         "Magnetometer heading fusion enabled on topic: %s "


### PR DESCRIPTION
Fixes #78

`sensor_msgs/MagneticField` is tesla, so `magnetometer.field_strength` and `magnetometer.hard_iron` are tesla and Earth's field is ~5e-5. Calibration tools print microtesla, where the same field reads as 50.

Entering `50` instead of `5e-5` fails silently and completely. `mag_field_disturbed` compares each reading's corrected magnitude against `field_strength`, so a clean 5e-5 T reading misses by 1e6 and is rejected as a magnetic disturbance:

```
|5.0e-05 - 50| = 50  >  0.2 * 50 = 10   ->  rejected
```

That holds for every reading, so no heading is ever produced and nothing in the log looks like a fault.

## Change

A predicate next to `mag_field_disturbed` in `magnetometer.hpp`, and two `RCLCPP_WARN` calls in `on_configure()` after the magnetometer parameters are read. Warning, not error — an unusual value may be deliberate.

```
magnetometer.field_strength is 50, far above Earth's field of ~5e-5.
sensor_msgs/MagneticField is TESLA, so this is probably microtesla: 50 uT is
5.00e-05 T. Left as is, every magnetometer reading is rejected as a magnetic
disturbance and you get no heading at all.
```

`hard_iron` is checked on the vector magnitude. The 1e-3 T threshold is loose against a plausible Earth field of 2.5e-5 to 6.5e-5, so only a real unit mistake reaches it. `0.0` is the default for both (gate off, hard iron uncalibrated) and stays quiet.

Test 16 in `test_magnetometer.cpp` covers the defaults, the plausible tesla span, the microtesla equivalents, the threshold boundary, and the `hard_iron` magnitude path.

## One thing worth your call

`fusioncore_ros/config/rowcrop_rtk.yaml:114` currently suggests exactly the value this now warns about:

```yaml
# magnetometer.field_strength: 50.0   # microtesla, your local Earth field
```

and the `MagParams` comment plus `docs/configuration.md` describe the parameter as being in "the SAME units as the incoming reading (e.g. ~0.48 for Gauss, ~48 for microtesla)". That reading is defensible for a driver that does not honour the message spec, but it is at odds with the framing in #78, and a user who uncomments that line will now get warned by the repo's own config.

I left all three alone since changing them goes past what the issue asked. Happy to follow up in this PR if you want them moved to tesla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
