### PR TITLE
fix(fusioncore): discard GPS track-heading windows on turns to prevent covariance collapse

### DIFF
--- a/fusioncore_core/include/fusioncore/fusioncore.hpp
+++ b/fusioncore_core/include/fusioncore/fusioncore.hpp
@@ -1008,6 +1008,19 @@ private:
   // heading error exceeds ~75 degrees.
   bool   gps_track_hdg_fused_ = false;
 
+  // True if |yaw_rate| exceeded gps_track_heading_max_yaw_rate at any point
+  // since last_hdg_fix_x_/y_ was last set. The GPS-track heading fusion
+  // computes its bearing as atan2(dy, dx) over that whole displacement --
+  // valid only if the path between the two points was roughly straight. A
+  // turn inside the window makes atan2 return the chord direction across the
+  // curve, not the robot's actual heading, and (because sigma_hdg depends
+  // only on GPS noise vs. distance, not on path curvature) that wrong bearing
+  // can still look "confident" enough to collapse the filter's own yaw
+  // covariance onto it. Set from update_distance_traveled()'s existing
+  // yaw_rate check; consumed and cleared in apply_gnss_update()'s heading
+  // fusion block.
+  bool   hdg_window_had_turn_ = false;
+
   // Returns heading 1-sigma in radians computed from P via quaternion-to-yaw Jacobian.
   double compute_heading_sigma_rad() const;
 

--- a/fusioncore_core/src/fusioncore.cpp
+++ b/fusioncore_core/src/fusioncore.cpp
@@ -487,6 +487,15 @@ void FusionCore::predict_to(double timestamp_seconds) {
 }
 
 void FusionCore::update_distance_traveled(double x, double y, double pre_update_speed) {
+  // Turn detection for the GPS-track heading fusion's displacement window
+  // (see hdg_window_had_turn_ declaration). Checked unconditionally, before
+  // the MIN_STEP early-return below: an in-place spin barely moves the GNSS
+  // antenna (dist stays near zero), so gating this on dist would miss
+  // exactly the case it exists to catch.
+  if (std::abs(ukf_.state().x[WZ]) > config_.gps_track_heading_max_yaw_rate) {
+    hdg_window_had_turn_ = true;
+  }
+
   if (!gnss_pos_set_) {
     last_gnss_x_  = x;
     last_gnss_y_  = y;
@@ -1462,6 +1471,19 @@ bool FusionCore::apply_gnss_update(
       last_hdg_fix_x_ = fix.x;
       last_hdg_fix_y_ = fix.y;
       hdg_fix_set_    = true;
+    } else if (hdg_window_had_turn_) {
+      // A turn happened somewhere between last_hdg_fix_x_/y_ and this fix.
+      // atan2(dy, dx) over that displacement would return the chord direction
+      // across the turn, not the robot's actual heading -- and since
+      // sigma_hdg below only reflects GPS noise vs. distance (not path
+      // curvature), that wrong bearing could still look "confident" enough
+      // to collapse the filter's own yaw covariance onto it (see
+      // hdg_window_had_turn_'s declaration). Discard this window instead of
+      // fusing: reset the reference to the current fix and start accumulating
+      // a fresh, hopefully-straight baseline from here.
+      last_hdg_fix_x_      = fix.x;
+      last_hdg_fix_y_      = fix.y;
+      hdg_window_had_turn_ = false;
     } else {
       double dx   = fix.x - last_hdg_fix_x_;
       double dy   = fix.y - last_hdg_fix_y_;


### PR DESCRIPTION
## Description
This Pull Request fixes a critical geometric bug in the GPS course-over-ground (*track heading*) calculation inside `apply_gnss_update()`.

### Problem
When deriving robot heading from GPS displacement (`atan2(dy, dx)` over a distance baseline), the system implicitly assumes a straight path between the two points. If the robot performs a turn within that accumulation window, `atan2` computes a chord direction across the curve rather than the actual heading. Because the heading measurement uncertainty (`sigma_hdg`) only accounts for GPS noise vs. distance (ignoring path curvature), this false bearing appears deceptively confident, causing the filter's yaw covariance to collapse onto it and corrupting the EKF estimate.

### Solution
* **Turn Detection:** Added `hdg_window_had_turn_`, tracking whether the robot's angular velocity (`WZ`) exceeds `gps_track_heading_max_yaw_rate` anywhere during the distance accumulation window inside `update_distance_traveled()`.
* **Window Invalidation:** When a GNSS update arrives, if a turn occurred within the baseline window, the update is safely discarded. The reference position (`last_hdg_fix_x_/y_`) is reset to the current fix, starting a fresh straight-line baseline from that point onward without injecting corrupted heading vectors into the UKF.

## Testing & Hardware Validation
* Tested and validated on a real Ground Mobile Robot (UGV) heavily dependent on a low-frequency GPS signal, featuring high-noise IMU and wheel encoder sensors, effectively preventing covariance collapse and trajectory distortion during tight maneuvers and in-place turns.